### PR TITLE
Modifier keys should not display as ^A

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 build
 xcuserdata
+xcshareddata

--- a/keycastr/KCKeystrokeTransformer.m
+++ b/keycastr/KCKeystrokeTransformer.m
@@ -49,10 +49,10 @@ static NSString* kShiftKeyString = nil;
 +(void) load
 {
 	NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-	kControlKeyString = [[NSString stringWithUTF8String:"\xe2\x8c\x83\x01"] retain];
-	kAltKeyString = [[NSString stringWithUTF8String:"\xe2\x8c\xa5\x01"] retain];
-	kCommandKeyString = [[NSString stringWithUTF8String:"\xe2\x8c\x98\x01"] retain];
-	kShiftKeyString = [[NSString stringWithUTF8String:"\xe2\x87\xa7\x01"] retain];
+	kControlKeyString = [[NSString stringWithUTF8String:"\xe2\x8c\x83"] retain];
+	kAltKeyString = [[NSString stringWithUTF8String:"\xe2\x8c\xa5"] retain];
+	kCommandKeyString = [[NSString stringWithUTF8String:"\xe2\x8c\x98"] retain];
+	kShiftKeyString = [[NSString stringWithUTF8String:"\xe2\x87\xa7"] retain];
 	[pool release];
 }
 
@@ -188,7 +188,7 @@ static NSString* kShiftKeyString = nil;
 	if (tmp != nil)
 	{
 		if (needsShiftGlyph)
-			[s appendString:[NSString stringWithUTF8String:"\xe2\x87\xa7\x01"]];
+			[s appendString:[NSString stringWithUTF8String:"\xe2\x87\xa7"]];
 		[s appendString:tmp];
 
 		return s;


### PR DESCRIPTION
This fixes issue #23.

I don't have a lot of experience creating unicode characters from hexadecimal values in objective-c, but everything I've seen implies that it's incorrect to append an extra `\x01` at the end. In the svelte visualizer, for example, these same hex strings appear, without the trailing `\x01`.

I also added a commit that adds xcsharedata to the gitignore. This is common to do for projects using XCode 5 or newer, when they added support for schemes. Since non-shared schemes belong to the user that created them, not having this ignored often results in a lot of noisy files being created that should not be tracked by git.