### PR TITLE
Fix typo: catastropic to catastropHic

### DIFF
--- a/keycastr/KCUtility.m
+++ b/keycastr/KCUtility.m
@@ -35,7 +35,7 @@ void KCFailLoudly( int expr, NSString *message )
 			NSApplicationLoad();
 		NSAlert *alert = [[[NSAlert alloc] init] autorelease];
 		[alert addButtonWithTitle:@"Close"];
-		[alert setMessageText:@"Catastropic Error Encountered"];
+		[alert setMessageText:@"Catastrophic Error Encountered"];
 		[alert setInformativeText:[NSString stringWithFormat:@"%@\n\nKeyCastr will now terminate.", message]];
 		[alert setAlertStyle:NSCriticalAlertStyle];
 		[alert runModal];


### PR DESCRIPTION
I just downloaded and ran this utility and got that typo in my face so I figured I could just as well fix it :-)