### PR TITLE
Update KCKeystrokeTransformer.m

### DIFF
--- a/keycastr/KCKeystrokeTransformer.m
+++ b/keycastr/KCKeystrokeTransformer.m
@@ -83,6 +83,53 @@ static NSString* kShiftKeyString = nil;
 	{
 		d = [[NSDictionary alloc] initWithObjectsAndKeys:
 			UTF8("\xe2\x87\xa4"), NSNum(48), // tab
+			UTF8("\x7E"), NSNum(50), // ~
+			UTF8("\x5f"), NSNum(27), // _
+			UTF8("\x2b"), NSNum(24), // +
+			UTF8("\x7b"), NSNum(33), // {
+			UTF8("\x7d"), NSNum(30), // }
+			UTF8("\x3a"), NSNum(41), // :
+			UTF8("\x22"), NSNum(39), // "
+			UTF8("\x3c"), NSNum(43), // <
+			UTF8("\x3e"), NSNum(47), // >
+			UTF8("\x3f"), NSNum(44), // ?
+			UTF8("\x7c"), NSNum(42), // |
+			UTF8("\x29"), NSNum(29), // )
+			UTF8("\x21"), NSNum(18), // !
+			UTF8("\x40"), NSNum(19), // @
+			UTF8("\x23"), NSNum(20), // #
+			UTF8("\x24"), NSNum(21), // $
+			UTF8("\x25"), NSNum(23), // %
+			UTF8("\x5e"), NSNum(22), // ^
+			UTF8("\x26"), NSNum(26), // &
+			UTF8("\x2a"), NSNum(28), // *
+			UTF8("\x28"), NSNum(25), // (
+			UTF8("A"), NSNum(0),
+			UTF8("B"), NSNum(11),
+			UTF8("C"), NSNum(8),
+			UTF8("D"), NSNum(2),
+			UTF8("E"), NSNum(14),
+			UTF8("F"), NSNum(3),
+			UTF8("G"), NSNum(5),
+			UTF8("H"), NSNum(4),
+			UTF8("I"), NSNum(34),
+			UTF8("J"), NSNum(38),
+			UTF8("K"), NSNum(40),
+			UTF8("L"), NSNum(37),
+			UTF8("M"), NSNum(46),
+			UTF8("N"), NSNum(45),
+			UTF8("O"), NSNum(31),
+			UTF8("P"), NSNum(35),
+			UTF8("Q"), NSNum(12),
+			UTF8("R"), NSNum(15),
+			UTF8("S"), NSNum(1),
+			UTF8("T"), NSNum(17),
+			UTF8("U"), NSNum(32),
+			UTF8("V"), NSNum(9),
+			UTF8("W"), NSNum(13),
+			UTF8("X"), NSNum(7),
+			UTF8("Y"), NSNum(16),
+			UTF8("Z"), NSNum(6),
 			nil];
 	}
 	return d;
@@ -174,7 +221,7 @@ static NSString* kShiftKeyString = nil;
 		[s appendString:kCommandKeyString];
 	}
 
-	if (isShifted)
+	if (isShifted && !isCommand)
 	{
 		id tmp = [[self _shiftedSpecialKeys] objectForKey:NSNum(_keyCode)];
 		if (tmp != nil)
@@ -188,7 +235,7 @@ static NSString* kShiftKeyString = nil;
 	if (tmp != nil)
 	{
 		if (needsShiftGlyph)
-			[s appendString:[NSString stringWithUTF8String:"\xe2\x87\xa7"]];
+			[s appendString:kShiftKeyString];
 		[s appendString:tmp];
 
 		return s;


### PR DESCRIPTION
update shift key mapping to reflect the the actual key pressed instead of original keys. The symbol of the shift key will only be displayed when combined with other key modifiers.
e.g. 
Shift+2 now will show up as "@" instead of "2"
Shift+h now will show up as "H" instead of "h"
Ctrl+Shift+a will show up as "⌃⇧A"