### PR TITLE
Fixes non-QWERTY layout issues

### DIFF
--- a/keycastr/KCAppController.m
+++ b/keycastr/KCAppController.m
@@ -70,6 +70,7 @@ static NSInteger kKCPrefDisplayIconInDock = 0x02;
 }
 
 - (void)dealloc {
+    [keyboardTap release];
     [statusItem release];
     [currentVisualizer release];
     [super dealloc];
@@ -89,7 +90,7 @@ static NSInteger kKCPrefDisplayIconInDock = 0x02;
 }
 
 -(void) installTap:(id)sender {
-    NSError* error;
+    NSError* error = nil;
     if (![keyboardTap installTapWithError:&error]) {
         NSAlert *alert = [[NSAlert new] autorelease];
         [alert addButtonWithTitle:@"Close"];
@@ -127,9 +128,14 @@ static NSInteger kKCPrefDisplayIconInDock = 0x02;
     }
 }
 
--(void) applicationWillFinishLaunching:(NSNotification *)notification {
+- (void)applicationWillFinishLaunching:(NSNotification *)notification {
     [self installTap:nil];
 }
+
+- (void)applicationWillTerminate:(NSNotification *)notification {
+    [keyboardTap removeTap];
+}
+
 
 -(void) _mapOldPreference:(NSString*)old toNewPreference:(NSString*)new
 {

--- a/keycastr/KCAppController.m
+++ b/keycastr/KCAppController.m
@@ -39,7 +39,7 @@ static NSString* kKCPrefSelectedVisualizer = @"selectedVisualizer";
 static NSInteger kKCPrefDisplayIconInMenuBar = 0x01;
 static NSInteger kKCPrefDisplayIconInDock = 0x02;
 
-@interface KCAppController ()
+@interface KCAppController ()<KCKeyboardTapDelegate>
 
 @property NSInteger prefDisplayIcon;
 @property BOOL showInDock;

--- a/keycastr/KCKeyboardTap.h
+++ b/keycastr/KCKeyboardTap.h
@@ -38,22 +38,19 @@
 @end
 
 @interface KCKeyboardTap : NSObject {
-    id _delegate;
+    id<KCKeyboardTapDelegate> _delegate;
     BOOL tapInstalled;
     CFMachPortRef keyboardTap;
     CFRunLoopRef keyboardTapRunLoop;
     CFRunLoopSourceRef keyboardTapEventSource;
 }
 
+@property (nonatomic, assign) id<KCKeyboardTapDelegate> delegate;
 
 -(BOOL) installTapWithError:(NSError**)error;
 -(void) removeTap;
 
 -(void) noteKeystroke:(KCKeystroke*)keystroke;
 -(void) noteFlagsChanged:(uint32_t)newFlags;
-
-
--(void) setDelegate:(id)delegate;
--(id) delegate;
 
 @end

--- a/keycastr/KCKeyboardTap.h
+++ b/keycastr/KCKeyboardTap.h
@@ -45,7 +45,6 @@
     CFRunLoopSourceRef keyboardTapEventSource;
 }
 
-+(KCKeyboardTap*) sharedKeyboardTap;
 
 -(BOOL) installTapWithError:(NSError**)error;
 -(void) removeTap;
@@ -53,8 +52,6 @@
 -(void) noteKeystroke:(KCKeystroke*)keystroke;
 -(void) noteFlagsChanged:(uint32_t)newFlags;
 
--(void) addObserver:(id)recipient selector:(SEL)aSelector;
--(void) removeObserver:(id)recipient;
 
 -(void) setDelegate:(id)delegate;
 -(id) delegate;

--- a/keycastr/KCKeyboardTap.h
+++ b/keycastr/KCKeyboardTap.h
@@ -50,7 +50,7 @@
 -(BOOL) installTapWithError:(NSError**)error;
 -(void) removeTap;
 
--(void) noteKeyEvent:(KCKeystroke*)keystroke;
+-(void) noteKeystroke:(KCKeystroke*)keystroke;
 -(void) noteFlagsChanged:(uint32_t)newFlags;
 
 -(void) addObserver:(id)recipient selector:(SEL)aSelector;

--- a/keycastr/KCKeyboardTap.m
+++ b/keycastr/KCKeyboardTap.m
@@ -68,6 +68,10 @@ CGEventRef eventTapCallback(
 }
 
 - (void)dealloc {
+    if (tapInstalled) {
+        [self removeTap];
+    }
+
     [super dealloc];
 }
 
@@ -140,8 +144,6 @@ CGEventRef eventTapCallback(
     }
     
     CFRunLoopAddSource(keyboardTapRunLoop, keyboardTapEventSource, kCFRunLoopDefaultMode);
-    CFRelease( keyboardTapEventSource );
-    CFRelease( keyboardTap );
 
     tapInstalled = YES;
     
@@ -155,7 +157,9 @@ CGEventRef eventTapCallback(
     
     CFRunLoopRemoveSource(keyboardTapRunLoop, keyboardTapEventSource, kCFRunLoopDefaultMode);
     CFRelease(keyboardTapRunLoop);
-    
+    CFRelease(keyboardTapEventSource);
+    CFRelease(keyboardTap);
+
     tapInstalled = NO;
 }
 

--- a/keycastr/KCKeyboardTap.m
+++ b/keycastr/KCKeyboardTap.m
@@ -102,7 +102,7 @@ CGEventRef eventTapCallback(
     
     if (tapKeyDown == NULL) {
         if (error != NULL) {
-            *error = [self constructErrorWithDescription:@"Could not create event tap!"];
+            *error = [self constructErrorWithDescription:@"Could not create keyDown event tap!"];
         }
         return NO;
     }
@@ -119,7 +119,7 @@ CGEventRef eventTapCallback(
     
     if (keyboardTap == NULL) {
         if (error != NULL) {
-            *error = [self constructErrorWithDescription:@"Could not create event tap!"];
+            *error = [self constructErrorWithDescription:@"Could not create keyDown|flagsChanged event tap!"];
         }
         return NO;
     }

--- a/keycastr/KCKeyboardTap.m
+++ b/keycastr/KCKeyboardTap.m
@@ -57,6 +57,8 @@ CGEventRef eventTapCallback(
 
 @implementation KCKeyboardTap
 
+@synthesize delegate = _delegate;
+
 -(id) init
 {
 	if (!(self = [super init]))
@@ -66,7 +68,6 @@ CGEventRef eventTapCallback(
 }
 
 - (void)dealloc {
-    [_delegate release];
     [super dealloc];
 }
 
@@ -189,27 +190,12 @@ CGEventRef eventTapCallback(
 
 -(void) noteKeystroke:(KCKeystroke*)keystroke
 {
-	if ([_delegate respondsToSelector:@selector(keyboardTap:noteKeystroke:)])
-		[_delegate keyboardTap:self noteKeystroke:keystroke];
+    [_delegate keyboardTap:self noteKeystroke:keystroke];
 }
 
 -(void) noteFlagsChanged:(uint32_t)newFlags
 {
-	if ([_delegate respondsToSelector:@selector(keyboardTap:noteFlagsChanged:)])
-		[_delegate keyboardTap:self noteFlagsChanged:newFlags];
-}
-
--(id) delegate
-{
-	return _delegate;
-}
-
--(void) setDelegate:(id)delegate
-{
-	if (delegate == _delegate)
-		return;
-	[_delegate release];
-	_delegate = [delegate retain];
+    [_delegate keyboardTap:self noteFlagsChanged:newFlags];
 }
 
 @end

--- a/keycastr/KCKeyboardTap.m
+++ b/keycastr/KCKeyboardTap.m
@@ -34,54 +34,6 @@
 
 @end
 
-/*
-static int
-GetKeyboardLayout( Ptr* resource )
-{
-    static Boolean initialized = false;
-    static SInt16 lastKeyLayoutID = -1;
-    static Handle uchrHnd = NULL;
-    static Handle KCHRHnd = NULL;
-
-    SInt16 keyScript;
-    SInt16 keyLayoutID;
-
-    keyScript = GetScriptManagerVariable(smKeyScript);
-    keyLayoutID = GetScriptVariable(keyScript,smScriptKeys);
-
-    if (!initialized || (lastKeyLayoutID != keyLayoutID)) {
-        initialized = true;
-        // deadKeyStateUp = deadKeyStateDown = 0;
-        lastKeyLayoutID = keyLayoutID;
-        uchrHnd = GetResource('uchr',keyLayoutID);
-        if (NULL == uchrHnd) {
-            KCHRHnd = GetResource('KCHR',keyLayoutID);
-        }
-        if ((NULL == uchrHnd) && (NULL == KCHRHnd)) {
-            initialized = false;
-            fprintf (stderr,
-                    "GetKeyboardLayout(): "
-                    "Can't get a keyboard layout for layout %d "
-                    "(error code %d)?\n",
-                    (int) keyLayoutID, (int) ResError());
-            *resource = (Ptr)GetScriptManagerVariable(smKCHRCache);
-            fprintf (stderr,
-                    "GetKeyboardLayout(): Trying the cache: %p\n",
-                    *resource);
-            return 0;
-        }
-    }
-
-    if (NULL != uchrHnd) {
-        *resource = *uchrHnd;
-        return 1;
-    } else {
-        *resource = *KCHRHnd;
-        return 0;
-    }
-}
-*/
-
 CGEventRef eventTapCallback(
    CGEventTapProxy proxy, 
    CGEventType type, 
@@ -245,28 +197,6 @@ CGEventRef eventTapCallback(
 {
 	if ([_delegate respondsToSelector:@selector(keyboardTap:noteFlagsChanged:)])
 		[_delegate keyboardTap:self noteFlagsChanged:newFlags];
-}
-
--(void) addObserver:(id)recipient selector:(SEL)aSelector
-{
-	NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
-	[center addObserver:recipient selector:aSelector name:@"KCKeystrokeEvent" object:self];
-}
-
--(void) removeObserver:(id)recipient
-{
-	NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
-	[center removeObserver:recipient];
-}
-
-+(KCKeyboardTap*) sharedKeyboardTap
-{
-	static KCKeyboardTap* sharedTap = nil;
-	if (sharedTap == nil)
-	{
-		sharedTap = [[KCKeyboardTap alloc] init];
-	}
-	return sharedTap;
 }
 
 -(id) delegate

--- a/keycastr/KCKeystroke.h
+++ b/keycastr/KCKeystroke.h
@@ -27,18 +27,18 @@
 
 #import <Cocoa/Cocoa.h>
 
-@interface KCKeystroke : NSObject
+@interface KCKeystroke : NSObject 
 {
-	uint16_t _keyCode;
-	uint16_t _charCode;
+    uint16_t _keyCode;
 	uint32_t _modifiers;
+    NSString *_charactersIgnoringModifiers;
 }
 
--(id) initWithKeyCode:(uint16_t)keyCode characterCode:(uint16_t)charCode modifiers:(uint32_t)modifiers;
+@property (nonatomic) uint16_t keyCode;
+@property (nonatomic) uint32_t modifiers;
+@property (nonatomic, copy) NSString *charactersIgnoringModifiers;
 
--(uint16_t) keyCode;
--(uint16_t) charCode;
--(uint32_t) modifiers;
+- (id)initWithKeyCode:(uint16_t)keyCode modifiers:(uint32_t)modifiers charactersIgnoringModifiers:(NSString *)charactersIgnoringModifiers;
 
 -(BOOL) isCommand;
 

--- a/keycastr/KCKeystroke.m
+++ b/keycastr/KCKeystroke.m
@@ -30,31 +30,23 @@
 
 @implementation KCKeystroke
 
--(id) initWithKeyCode:(uint16_t)keyCode characterCode:(uint16_t)charCode modifiers:(uint32_t)modifiers;
-{
+@synthesize keyCode = _keyCode, modifiers = _modifiers, charactersIgnoringModifiers = _charactersIgnoringModifiers;
+
+- (id)initWithKeyCode:(uint16_t)keyCode modifiers:(uint32_t)modifiers charactersIgnoringModifiers:(NSString *)charactersIgnoringModifiers {
 	if (!(self = [super init]))
 		return nil;
 
 	_keyCode = keyCode;
-	_charCode = charCode;
 	_modifiers = modifiers;
+	_charactersIgnoringModifiers = [charactersIgnoringModifiers copy];
 
 	return self;
 }
 
--(uint16_t) keyCode
-{
-	return _keyCode;
-}
-
--(uint32_t) modifiers
-{
-	return _modifiers;
-}
-
--(uint16_t) charCode
-{
-	return _charCode;
+- (void)dealloc {
+	[_charactersIgnoringModifiers release];
+	_charactersIgnoringModifiers = nil;
+	[super dealloc];
 }
 
 -(BOOL) isCommand

--- a/keycastr/KCKeystrokeTransformer.m
+++ b/keycastr/KCKeystrokeTransformer.m
@@ -119,6 +119,11 @@ static NSString* kShiftKeyString = nil;
 	return d;
 }
 
+- (NSString *)leftTabString
+{
+    return @"\xe2\x87\xa4";
+}
+
 -(id) transformedValue:(id)value
 {
 	KCKeystroke* v = (KCKeystroke*)value;
@@ -162,14 +167,14 @@ static NSString* kShiftKeyString = nil;
 
 	if (isShifted && !isCommand)
 	{
-		NSString *tmp = v.charactersIgnoringModifiers;
+        NSString *tmp = [@(_keyCode) isEqualToNumber:@48] ? [self leftTabString] : v.charactersIgnoringModifiers;
 		if (tmp) {
 			[s appendString:tmp];
 			return s;
 		}
 	}
 
-	id tmp = [[self _specialKeys] objectForKey:NSNum(_keyCode)];
+	id tmp = [[self _specialKeys] objectForKey:@(_keyCode)];
 	if (tmp != nil)
 	{
 		if (needsShiftGlyph)

--- a/keycastr/KCKeystrokeTransformer.m
+++ b/keycastr/KCKeystrokeTransformer.m
@@ -126,11 +126,11 @@ static NSString* kShiftKeyString = nil;
 
 -(id) transformedValue:(id)value
 {
-	KCKeystroke* v = (KCKeystroke*)value;
-	NSMutableString* s = [NSMutableString string];
+	KCKeystroke* keystroke = (KCKeystroke*)value;
+	NSMutableString* mutableResponse = [NSMutableString string];
 
-	uint32_t _modifiers = [v modifiers];
-	uint16_t _keyCode = [v keyCode];
+	uint32_t _modifiers = [keystroke modifiers];
+	uint16_t _keyCode = [keystroke keyCode];
 
 	BOOL isShifted = NO;
 	BOOL needsShiftGlyph = NO;
@@ -139,18 +139,18 @@ static NSString* kShiftKeyString = nil;
 	if (_modifiers & NSControlKeyMask)
 	{
 		isCommand = YES;
-		[s appendString:kControlKeyString];
+		[mutableResponse appendString:kControlKeyString];
 	}
 	if (_modifiers & NSAlternateKeyMask)
 	{
 		isCommand = YES;
-		[s appendString:kAltKeyString];
+		[mutableResponse appendString:kAltKeyString];
 	}
 	if (_modifiers & NSShiftKeyMask)
 	{
 		isShifted = YES;
 		if (isCommand)
-			[s appendString:kShiftKeyString];
+			[mutableResponse appendString:kShiftKeyString];
 		else
 			needsShiftGlyph = YES;
 	}
@@ -158,19 +158,19 @@ static NSString* kShiftKeyString = nil;
 	{
 		if (needsShiftGlyph)
 		{
-			[s appendString:kShiftKeyString];
+			[mutableResponse appendString:kShiftKeyString];
 			needsShiftGlyph = NO;
 		}
 		isCommand = YES;
-		[s appendString:kCommandKeyString];
+		[mutableResponse appendString:kCommandKeyString];
 	}
 
 	if (isShifted && !isCommand)
 	{
-        NSString *tmp = [@(_keyCode) isEqualToNumber:@48] ? [self leftTabString] : v.charactersIgnoringModifiers;
+        NSString *tmp = [@(_keyCode) isEqualToNumber:@48] ? [self leftTabString] : keystroke.charactersIgnoringModifiers;
 		if (tmp) {
-			[s appendString:tmp];
-			return s;
+			[mutableResponse appendString:tmp];
+			return mutableResponse;
 		}
 	}
 
@@ -178,22 +178,21 @@ static NSString* kShiftKeyString = nil;
 	if (tmp != nil)
 	{
 		if (needsShiftGlyph)
-			[s appendString:kShiftKeyString];
-		[s appendString:tmp];
+			[mutableResponse appendString:kShiftKeyString];
+		[mutableResponse appendString:tmp];
 
-		return s;
+		return mutableResponse;
 	}
 
-	[s appendString:v.charactersIgnoringModifiers];
+	[mutableResponse appendString:keystroke.charactersIgnoringModifiers];
 
 	// If this is a command string, put it in uppercase.
 	if (isCommand)
 	{
-		NSMutableString *t = [[s uppercaseString] mutableCopy];
-        s = [t autorelease];
+        mutableResponse = [[[mutableResponse uppercaseString] mutableCopy] autorelease];
 	}
 	
-	return s;
+	return mutableResponse;
 }
 
 @end

--- a/keycastr/KCKeystrokeTransformer.m
+++ b/keycastr/KCKeystrokeTransformer.m
@@ -30,7 +30,6 @@
 
 @interface KCKeystrokeTransformer (Private)
 
--(NSDictionary*) _shiftedSpecialKeys;
 -(NSDictionary*) _specialKeys;
 
 @end
@@ -74,39 +73,6 @@ static NSString* kShiftKeyString = nil;
 		xformer = [[KCKeystrokeTransformer alloc] init];
 	}
 	return xformer;
-}
-
--(NSDictionary*) _shiftedSpecialKeys
-{
-	static NSDictionary *d = nil;
-	if (d == nil)
-	{
-		d = [[NSDictionary alloc] initWithObjectsAndKeys:
-			UTF8("\xe2\x87\xa4"), NSNum(48), // tab
-			UTF8("\x7E"), NSNum(50), // ~
-			UTF8("\x5f"), NSNum(27), // _
-			UTF8("\x2b"), NSNum(24), // +
-			UTF8("\x7b"), NSNum(33), // {
-			UTF8("\x7d"), NSNum(30), // }
-			UTF8("\x3a"), NSNum(41), // :
-			UTF8("\x22"), NSNum(39), // "
-			UTF8("\x3c"), NSNum(43), // <
-			UTF8("\x3e"), NSNum(47), // >
-			UTF8("\x3f"), NSNum(44), // ?
-			UTF8("\x7c"), NSNum(42), // |
-			UTF8("\x29"), NSNum(29), // )
-			UTF8("\x21"), NSNum(18), // !
-			UTF8("\x40"), NSNum(19), // @
-			UTF8("\x23"), NSNum(20), // #
-			UTF8("\x24"), NSNum(21), // $
-			UTF8("\x25"), NSNum(23), // %
-			UTF8("\x5e"), NSNum(22), // ^
-			UTF8("\x26"), NSNum(26), // &
-			UTF8("\x2a"), NSNum(28), // *
-			UTF8("\x28"), NSNum(25), // (
-			nil];
-	}
-	return d;
 }
 
 -(NSDictionary*) _specialKeys
@@ -160,8 +126,7 @@ static NSString* kShiftKeyString = nil;
 
 	uint32_t _modifiers = [v modifiers];
 	uint16_t _keyCode = [v keyCode];
-	uint16_t _charCode = [v charCode];
-	
+
 	BOOL isShifted = NO;
 	BOOL needsShiftGlyph = NO;
 	BOOL isCommand = NO;
@@ -197,13 +162,8 @@ static NSString* kShiftKeyString = nil;
 
 	if (isShifted && !isCommand)
 	{
-		id tmp = [[self _shiftedSpecialKeys] objectForKey:NSNum(_keyCode)];
-        if (!tmp)
-        {
-            tmp = [[NSString stringWithCharacters:&_charCode length:1] uppercaseString];
-        }
-		if (tmp)
-		{
+		NSString *tmp = v.charactersIgnoringModifiers;
+		if (tmp) {
 			[s appendString:tmp];
 			return s;
 		}
@@ -219,7 +179,7 @@ static NSString* kShiftKeyString = nil;
 		return s;
 	}
 
-	[s appendString:[NSString stringWithCharacters:&_charCode length:1]];
+	[s appendString:v.charactersIgnoringModifiers];
 
 	// If this is a command string, put it in uppercase.
 	if (isCommand)

--- a/keycastr/KeyCastr.xcodeproj/project.pbxproj
+++ b/keycastr/KeyCastr.xcodeproj/project.pbxproj
@@ -32,7 +32,6 @@
 		3D3F52BA0F30C68B001C7272 /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D3F52B90F30C68B001C7272 /* Quartz.framework */; };
 		3D3F52EB0F30CB13001C7272 /* KCPrefsWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D3F52EA0F30CB13001C7272 /* KCPrefsWindowController.m */; };
 		3D3F540C0F30E8E7001C7272 /* KCKeyboardTap.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D3F540B0F30E8E7001C7272 /* KCKeyboardTap.m */; };
-		3D3F540E0F30E914001C7272 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D3F540D0F30E914001C7272 /* Carbon.framework */; };
 		3D3F548A0F30F37E001C7272 /* GeneralIcon.tif in Resources */ = {isa = PBXBuildFile; fileRef = 3D3F54870F30F37E001C7272 /* GeneralIcon.tif */; };
 		3D3F548B0F30F37E001C7272 /* DisplayIcon.tif in Resources */ = {isa = PBXBuildFile; fileRef = 3D3F54880F30F37E001C7272 /* DisplayIcon.tif */; };
 		3D3F548E0F30F3C7001C7272 /* UpdateIcon.tif in Resources */ = {isa = PBXBuildFile; fileRef = 3D3F548D0F30F3C7001C7272 /* UpdateIcon.tif */; };
@@ -116,7 +115,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		089C165DFE840E0CC02AAC07 /* English */ = {isa = PBXFileReference; fileEncoding = 10; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		089C165DFE840E0CC02AAC07 /* English */ = {isa = PBXFileReference; fileEncoding = 2483028224; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		13E42FB307B3F0F600E4EEF1 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = /System/Library/Frameworks/CoreData.framework; sourceTree = "<absolute>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -146,7 +145,6 @@
 		3D3F52EA0F30CB13001C7272 /* KCPrefsWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KCPrefsWindowController.m; sourceTree = "<group>"; };
 		3D3F540A0F30E8E7001C7272 /* KCKeyboardTap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KCKeyboardTap.h; sourceTree = "<group>"; };
 		3D3F540B0F30E8E7001C7272 /* KCKeyboardTap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KCKeyboardTap.m; sourceTree = "<group>"; };
-		3D3F540D0F30E914001C7272 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = /System/Library/Frameworks/Carbon.framework; sourceTree = "<absolute>"; };
 		3D3F54870F30F37E001C7272 /* GeneralIcon.tif */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = GeneralIcon.tif; sourceTree = "<group>"; };
 		3D3F54880F30F37E001C7272 /* DisplayIcon.tif */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = DisplayIcon.tif; sourceTree = "<group>"; };
 		3D3F548D0F30F3C7001C7272 /* UpdateIcon.tif */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = UpdateIcon.tif; sourceTree = "<group>"; };
@@ -201,7 +199,6 @@
 			files = (
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
 				3D3F52BA0F30C68B001C7272 /* Quartz.framework in Frameworks */,
-				3D3F540E0F30E914001C7272 /* Carbon.framework in Frameworks */,
 				3D3F56410F32D266001C7272 /* ShortcutRecorder.framework in Frameworks */,
 				3D1646F40F43DD8300CA65AD /* KCVisualizer.framework in Frameworks */,
 				3DF883890F5256FF005FD1C6 /* Sparkle.framework in Frameworks */,
@@ -274,7 +271,6 @@
 			children = (
 				3DF8835C0F5254F9005FD1C6 /* Sparkle.framework */,
 				3D3F56400F32D266001C7272 /* ShortcutRecorder.framework */,
-				3D3F540D0F30E914001C7272 /* Carbon.framework */,
 				3D3F52B90F30C68B001C7272 /* Quartz.framework */,
 				1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */,
 				29B97324FDCFA39411CA2CEA /* AppKit.framework */,


### PR DESCRIPTION
With these fixes, the only keys handled with special casing are the keys which don't have a glyph associated with them automatically (like the arrows, space bar, tab, etc.). This addresses #56 etc.

This change removes the dependency on Carbon APIs, relying instead on NSEvent which may use a bit more memory. I haven't inspected this impact yet, but I'm not too worried about it... I may continue to update this PR before merging, but anyone can go ahead and try out the build in the ```keycastr/bin/``` folder. 

Feedback is especially welcome from non-QWERTY and non-US users -- in fact it would be greatly appreciated! I tested Dvorak and Colemak using the input sources menu in macOS, not an actual hardware keyboard.