### PR TITLE
README: update HBC install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ KeyCastr, an open-source keystroke visualizer.
 ## Installation via [homebrew](http://brew.sh/) [cask](https://github.com/caskroom/homebrew-cask)
 
 ```console
-which cask || brew tap caskroom/cask # Get cask if you don't already have it
 brew cask install keycastr
 ```
 ## Accessibility API access


### PR DESCRIPTION
`which cask` would’ve never worked universally, since we don’t expose just a `cask` command. Either way, for a long time now you don’t need to tap the repo: running any `brew cask` command will do it automatically.