### PR TITLE
Fixes visualizer persisting across spaces

### DIFF
--- a/keycastr/KCDefaultVisualizer.m
+++ b/keycastr/KCDefaultVisualizer.m
@@ -93,6 +93,7 @@
 			styleMask:NSBorderlessWindowMask
 			backing:NSBackingStoreBuffered
 			defer:NO];
+		[visualizerWindow setCollectionBehavior: NSWindowCollectionBehaviorCanJoinAllSpaces];
 		[visualizerWindow orderFront:self];
 	}
 }


### PR DESCRIPTION
## What

Sets the visualizer to `canJoinAllSpaces` so it appears on all desktops, instead of being left behind when switching.

## Why

When moving across spaces or desktops the visualizer was left on the first one. This made it hard when switching between apps on different desktops, e.g. when demoing a browser on one desktop and switching to code in another

## Why not

It might be be preferable to use `moveToActiveSpace` instead, so it doesn't appear on multiple monitors. Users with multiple screens could also want an option between the two.