### PR TITLE
Support F17/F18/F19/F20 functions keys

### DIFF
--- a/keycastr/KCKeystrokeTransformer.m
+++ b/keycastr/KCKeystrokeTransformer.m
@@ -104,6 +104,10 @@ static NSString* kLeftTabString = @"\xe2\x87\xa4";
 			UTF8("F14"), NSNum(107), // F14
 			UTF8("F15"), NSNum(113), // F15
 			UTF8("F16"), NSNum(106), // F16
+			UTF8("F17"), NSNum(64), // F17
+			UTF8("F18"), NSNum(79), // F18
+			UTF8("F19"), NSNum(80), // F19
+			UTF8("F20"), NSNum(90), // F20
 			UTF8("\xe2\x90\xa3\xe2\x80\x8b"), NSNum(49), // space
 			nil];
 	}


### PR DESCRIPTION
for this issue  https://github.com/keycastr/keycastr/issues/99

and i have same situation.

the key code from here https://eastmanreference.com/complete-list-of-applescript-key-codes

![image](https://user-images.githubusercontent.com/1265888/64754319-68e2a400-d559-11e9-968d-bb951205f937.png)

preview:

![image](https://user-images.githubusercontent.com/1265888/64754278-43559a80-d559-11e9-86dd-dc3376a13316.png)


![image](https://user-images.githubusercontent.com/1265888/64754275-3df85000-d559-11e9-9fb8-608cca8809b4.png)
