### PR TITLE
tweak homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ KeyCastr, an open-source keystroke visualizer.
 ## Installation via [homebrew](http://brew.sh/) [cask](https://github.com/caskroom/homebrew-cask)
 
 ```console
-brew cask install keycastr
+brew install --cask keycastr
 ```
 
 ## Enabling Accessibility API Access


### PR DESCRIPTION
to solve this deprecation warning:
> Warning: Calling brew cask install is deprecated! Use brew install [--cask] instead.