### PR TITLE
Add the option for KCDefaultVisualiser to show flags

### DIFF
--- a/keycastr/KCDefaultVisualizer.h
+++ b/keycastr/KCDefaultVisualizer.h
@@ -80,12 +80,14 @@
 - (void)abandonCurrentBezelView;
 - (void)addKeystroke:(KCKeystroke *)keystroke;
 - (void)addRunningAnimation:(KCBezelAnimation *)animation;
+- (void)scheduleStickyBezelFadeOutIfNeeded;
 
 @end
 
 @interface KCDefaultVisualizer : KCVisualizer <KCVisualizer>
 {
 	KCDefaultVisualizerWindow* visualizerWindow;
+	KCKeystroke *lastFlagChangeKeystroke;
 }
 
 -(NSString*) visualizerName;

--- a/keycastr/KCDefaultVisualizer.m
+++ b/keycastr/KCDefaultVisualizer.m
@@ -120,7 +120,38 @@
 		// This is not a command key, and we want to only display command keys, so we ignore this.
 		return;
 	}
+
+	[self cancelFlagOnlyKeystrokeDebounce];
 	[visualizerWindow addKeystroke:keystroke];
+}
+
+- (void) noteFlagsChanged:(uint32_t)flags
+{
+	if ([[[NSUserDefaults standardUserDefaults] valueForKey:@"default.enableShowModifierPresses"] boolValue])
+	{
+		KCKeystroke *stroke = [[KCKeystroke alloc] initWithKeyCode:0 modifiers:flags charactersIgnoringModifiers: @""];
+
+		[self cancelFlagOnlyKeystrokeDebounce];
+
+		if (flags == 0 || flags == NSShiftKeyMask)
+		{
+			// If there are no flags or this is _only_ a shift key, do nothing
+			return;
+		}
+
+		// Debounce because flags change one by one, .e.g we will get three events if we hold down three modifier keys at once
+		lastFlagChangeKeystroke = stroke;
+		[visualizerWindow performSelector:@selector(addKeystroke:) withObject:stroke afterDelay: 0.3];
+	}
+}
+
+- (void)cancelFlagOnlyKeystrokeDebounce
+{
+    [NSObject cancelPreviousPerformRequestsWithTarget:visualizerWindow selector:@selector(addKeystroke:) object: lastFlagChangeKeystroke];
+    lastFlagChangeKeystroke = nil;
+
+    // Fade out sticky modifier key bezels
+    [visualizerWindow scheduleStickyBezelFadeOutIfNeeded];
 }
 
 @end
@@ -226,12 +257,29 @@
 		[self setFrame:frame display:YES animate:NO];
 
 		[[self contentView] addSubview:_currentBezelView];
+
+		if (keystroke.keyCode != 0)
+		{
+			// If this is a real key down, schedule the fade out
+			// In other words, leave the bezel on screen whilst modified keys are held down
+			[_currentBezelView scheduleFadeOut];
+		}
 	}
 	else
 	{
 		[_currentBezelView appendString:charString];
 	}
-    [self _scheduleLineBreak];
+
+	if (keystroke.keyCode != 0)
+	{
+		[self _scheduleLineBreak];
+	}
+}
+
+-(void) scheduleStickyBezelFadeOutIfNeeded
+{
+    [_currentBezelView scheduleFadeOut];
+    [self abandonCurrentBezelView];
 }
 
 -(void) abandonCurrentView
@@ -392,7 +440,6 @@ static const int kKCBezelBorder = 6;
 	[self setAutoresizingMask:NSViewMinYMargin];
 
 	[self maybeResize];
-	[self scheduleFadeOut];
 
 	return self;
 }


### PR DESCRIPTION
[reopened to target `main` branch]

I guess this is similar to the Mod Keys pull request (which I only discovered after doing this work ahahah 😅)

This PR adds an option for KCDefaultVisualiser to show held-down modifier keys - well, actually, I wasn't entirely sure how to make the binding between the storyboard checkbox and NSUserDefaults so I was hoping someone else could help with that.. But at any rate, putting the following into the command line will set the user defaults flag to true and enable the feature:

defaults write io.github.keycastr default.enableShowModifierPresses -bool true

This is really useful for when screencasting Xcode (of all things) due to there being so many times I need to show that I'm holding down keys whilst pressing a mouse button.

I hope this helps someone in the future, and apologies in advance as it's been.. 5 or so years since I had to write any Objective-C 🙃