### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "keycastr/Externals/ShortcutRecorder"]
 	path = keycastr/Externals/ShortcutRecorder
-	url = git@github.com:Kentzo/ShortcutRecorder.git
+	url = https://github.com/Kentzo/ShortcutRecorder.git
 [submodule "keycastr/Externals/Sparkle"]
 	path = keycastr/Externals/Sparkle
-	url = git@github.com:sparkle-project/Sparkle.git
+	url = https://github.com/sparkle-project/Sparkle.git


### PR DESCRIPTION
When trying to run git submodule update --init --recursive I couldn't get it to run and got the error:

Submodule 'keycastr/Externals/ShortcutRecorder' (git@github.com:Kentzo/ShortcutRecorder.git) registered for path 'keycastr/Externals/ShortcutRecorder'
Submodule 'keycastr/Externals/Sparkle' (git@github.com:sparkle-project/Sparkle.git) registered for path 'keycastr/Externals/Sparkle'
Cloning into '/Volumes/Data/keycastr/keycastr/Externals/ShortcutRecorder'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:Kentzo/ShortcutRecorder.git' into submodule path '/Volumes/Data/keycastr/keycastr/Externals/ShortcutRecorder' failed
Failed to clone 'keycastr/Externals/ShortcutRecorder'. Retry scheduled
Cloning into '/Volumes/Data/keycastr/keycastr/Externals/Sparkle'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:sparkle-project/Sparkle.git' into submodule path '/Volumes/Data/keycastr/keycastr/Externals/Sparkle' failed
Failed to clone 'keycastr/Externals/Sparkle'. Retry scheduled
Cloning into '/Volumes/Data/keycastr/keycastr/Externals/ShortcutRecorder'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:Kentzo/ShortcutRecorder.git' into submodule path '/Volumes/Data/keycastr/keycastr/Externals/ShortcutRecorder' failed
Failed to clone 'keycastr/Externals/ShortcutRecorder' a second time, aborting
Duythanh@DuyThanhs-MacBook-Pro keycastr % git submodule update --init --recursive
Cloning into '/Volumes/Data/keycastr/keycastr/Externals/ShortcutRecorder'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:Kentzo/ShortcutRecorder.git' into submodule path '/Volumes/Data/keycastr/keycastr/Externals/ShortcutRecorder' failed
Failed to clone 'keycastr/Externals/ShortcutRecorder'. Retry scheduled
Cloning into '/Volumes/Data/keycastr/keycastr/Externals/Sparkle'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:sparkle-project/Sparkle.git' into submodule path '/Volumes/Data/keycastr/keycastr/Externals/Sparkle' failed
Failed to clone 'keycastr/Externals/Sparkle'. Retry scheduled
Cloning into '/Volumes/Data/keycastr/keycastr/Externals/ShortcutRecorder'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:Kentzo/ShortcutRecorder.git' into submodule path '/Volumes/Data/keycastr/keycastr/Externals/ShortcutRecorder' failed
Failed to clone 'keycastr/Externals/ShortcutRecorder' a second time, aborting

So I tried changing in .gitmodules, ShortcutRecorder url line to https://github.com/Kentzo/ShortcutRecorder.git and Sparkle url line to https://github.com/sparkle-project/Sparkle.git , and it ran successfully on my Mac, currently running macOS Big Sur 11.6.1. Before that I also tried adding SSH keys according to GitHub's documentation and it was useless.