### PR TITLE
Add dual notation feature (macOS + Windows) for keystroke display

### DIFF
--- a/keycastr/KCDefaultVisualizer.h
+++ b/keycastr/KCDefaultVisualizer.h
@@ -96,6 +96,7 @@ typedef NS_ENUM(NSInteger, KCDefaultVisualizerDisplayOption) {
 @property (nonatomic, assign) IBOutlet NSButton *commandKeysOnlyButton;
 @property (nonatomic, assign) IBOutlet NSButton *allModifiedKeysButton;
 @property (nonatomic, assign) IBOutlet NSButton *allKeysButton;
+@property (nonatomic, strong) NSButton *showDualNotationCheckbox;
 
 @end
 

--- a/keycastr/KCDefaultVisualizer.m
+++ b/keycastr/KCDefaultVisualizer.m
@@ -74,7 +74,8 @@ static const CGFloat kKCDefaultBezelPadding = 10.0;
     // Create the dual notation checkbox programmatically
     _showDualNotationCheckbox = [[NSButton alloc] initWithFrame:NSMakeRect(20, 20, 300, 25)];
     [_showDualNotationCheckbox setButtonType:NSButtonTypeSwitch];
-    [_showDualNotationCheckbox setTitle:@"Show dual notation (macOS + Windows)"];
+    [_showDualNotationCheckbox setTitle:NSLocalizedString(@"Show dual notation (macOS + Windows)",
+                                                          @"Checkbox label for enabling dual platform notation display")];
     [_showDualNotationCheckbox setTarget:self];
     [_showDualNotationCheckbox setAction:@selector(showDualNotationChanged:)];
 

--- a/keycastr/KCEventTransformer.h
+++ b/keycastr/KCEventTransformer.h
@@ -40,5 +40,6 @@
 + (instancetype)new NS_UNAVAILABLE;
 
 - (id)transformedValue:(KCKeycastrEvent *)event;
+- (NSString *)transformedValueToWindowsNotation:(KCKeycastrEvent *)event;
 
 @end

--- a/keycastr/KCEventTransformer.m
+++ b/keycastr/KCEventTransformer.m
@@ -62,6 +62,12 @@ static NSString* kControlKeyString = @"\xe2\x8c\x83";
 static NSString* kShiftKeyString = @"\xe2\x87\xa7";
 static NSString* kLeftTabString = @"\xe2\x87\xa4";
 
+// Key codes for special handling
+static const uint16_t kKeyCodeMinus = 27;
+static const uint16_t kKeyCodeReturn = 36;
+static const uint16_t kKeyCodeNumpadEnter = 76;
+static const uint16_t kKeyCodeTab = 48;
+
 #define UTF8(x) [NSString stringWithUTF8String:x]
 
 @synthesize keyboardLayout = _keyboardLayout;
@@ -269,7 +275,7 @@ static NSString* kLeftTabString = @"\xe2\x87\xa4";
     // check for bare shift-tab as left tab special case
     if (hasShiftModifier && !keystroke.isCommand && !hasOptionModifier)
     {
-        if (keystroke.keyCode == 48) {
+        if (keystroke.keyCode == kKeyCodeTab) {
             [mutableResponse appendString:kLeftTabString];
             return mutableResponse;
         }
@@ -313,8 +319,8 @@ static NSString* kLeftTabString = @"\xe2\x87\xa4";
     // Commands, shifted keystrokes, and option combinations (when displayModifiedCharacters is NO) should be uppercased
     if (isCommand || hasShiftModifier || (hasOptionModifier && !_displayModifiedCharacters))
     {
-        // Unless it is a special case - do not shift keycode 27
-        if (keystroke.keyCode != 27) {
+        // Special case: Don't uppercase the minus key (German ß key)
+        if (keystroke.keyCode != kKeyCodeMinus) {
             mutableResponse = [[mutableResponse uppercaseString] mutableCopy];
         }
 	}
@@ -346,53 +352,58 @@ static NSString* kLeftTabString = @"\xe2\x87\xa4";
 
 - (NSDictionary *)_windowsSpecialKeys
 {
-    static NSDictionary *d = nil;
-    if (d == nil) {
-        d = [[NSDictionary alloc] initWithObjectsAndKeys:
-             @"Up", @126,        // up
-             @"Down", @125,      // down
-             @"Right", @124,     // right
-             @"Left", @123,      // left
-             @"Tab", @48,        // tab
-             @"Esc", @53,        // escape
-             @"Clear", @71,      // clear
-             @"Backspace", @51,  // delete
-             @"Delete", @117,    // forward delete
-             @"Help", @114,      // help
-             @"Home", @115,      // home
-             @"End", @119,       // end
-             @"PgUp", @116,      // pgup
-             @"PgDn", @121,      // pgdn
-             @"Enter", @36,      // return
-             @"Enter", @76,      // numpad enter
-             @"Space", @49,      // space
-             @"F1", @122,        // F1
-             @"F2", @120,        // F2
-             @"F3", @99,         // F3
-             @"F4", @118,        // F4
-             @"F5", @96,         // F5
-             @"F6", @97,         // F6
-             @"F7", @98,         // F7
-             @"F8", @100,        // F8
-             @"F9", @101,        // F9
-             @"F10", @109,       // F10
-             @"F11", @103,       // F11
-             @"F12", @111,       // F12
-             @"F13", @105,       // F13
-             @"F14", @107,       // F14
-             @"F15", @113,       // F15
-             @"F16", @106,       // F16
-             @"F17", @64,        // F17
-             @"F18", @79,        // F18
-             @"F19", @80,        // F19
-             @"F20", @90,        // F20
-             nil];
-    }
-    return d;
+    static NSDictionary *specialKeys = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        specialKeys = @{
+            @126: @"Up",           // up arrow
+            @125: @"Down",         // down arrow
+            @124: @"Right",        // right arrow
+            @123: @"Left",         // left arrow
+            @kKeyCodeTab: @"Tab",  // tab
+            @53: @"Esc",           // escape
+            @71: @"Clear",         // clear
+            @51: @"Backspace",     // delete
+            @117: @"Delete",       // forward delete
+            @114: @"Help",         // help
+            @115: @"Home",         // home
+            @119: @"End",          // end
+            @116: @"PgUp",         // page up
+            @121: @"PgDn",         // page down
+            @kKeyCodeReturn: @"Enter",       // return
+            @kKeyCodeNumpadEnter: @"Enter",  // numpad enter
+            @49: @"Space",         // space
+            @122: @"F1",           // F1
+            @120: @"F2",           // F2
+            @99: @"F3",            // F3
+            @118: @"F4",           // F4
+            @96: @"F5",            // F5
+            @97: @"F6",            // F6
+            @98: @"F7",            // F7
+            @100: @"F8",           // F8
+            @101: @"F9",           // F9
+            @109: @"F10",          // F10
+            @103: @"F11",          // F11
+            @111: @"F12",          // F12
+            @105: @"F13",          // F13
+            @107: @"F14",          // F14
+            @113: @"F15",          // F15
+            @106: @"F16",          // F16
+            @64: @"F17",           // F17
+            @79: @"F18",           // F18
+            @80: @"F19",           // F19
+            @90: @"F20",           // F20
+        };
+    });
+    return specialKeys;
 }
 
 - (NSString *)transformedValueToWindowsNotation:(KCKeycastrEvent *)event
 {
+    if (!event) {
+        return @"";
+    }
+
     NSEventModifierFlags _modifiers = event.modifierFlags;
     BOOL hasControlModifier = (_modifiers & NSEventModifierFlagControl) != 0;
     BOOL hasOptionModifier = (_modifiers & NSEventModifierFlagOption) != 0;
@@ -436,7 +447,7 @@ static NSString* kLeftTabString = @"\xe2\x87\xa4";
 
     // check for bare shift-tab as left tab special case
     if (hasShiftModifier && !keystroke.isCommand && !hasOptionModifier) {
-        if (keystroke.keyCode == 48) {
+        if (keystroke.keyCode == kKeyCodeTab) {
             return @"Shift+Tab";
         }
     }
@@ -484,7 +495,8 @@ static NSString* kLeftTabString = @"\xe2\x87\xa4";
 
         // Commands, shifted keystrokes, and option combinations should be uppercased
         if (isCommand || hasShiftModifier || (hasOptionModifier && !_displayModifiedCharacters)) {
-            if (keystroke.keyCode != 27) {
+            // Special case: Don't uppercase the minus key (German ß key)
+            if (keystroke.keyCode != kKeyCodeMinus) {
                 keyPart = [keyPart uppercaseString];
             }
         }

--- a/keycastr/KCVisualizerTests/KCKeystrokeConversionTests.m
+++ b/keycastr/KCVisualizerTests/KCKeystrokeConversionTests.m
@@ -281,4 +281,48 @@
     XCTAssertEqualObjects([keystroke convertToString], @"⌘ß");
 }
 
+#pragma mark - Windows Notation Conversion
+
+- (void)test_windowsNotation_convertsCmdCToCtrlC {
+    // cmd-C should convert to Ctrl+C in Windows notation
+    keystroke = [self keystrokeWithKeyCode:8 modifiers:1048840 characters:@"c" charactersIgnoringModifiers:@"c"];
+    XCTAssertEqualObjects([eventTransformer transformedValueToWindowsNotation:keystroke], @"Ctrl+C");
+}
+
+- (void)test_windowsNotation_convertsCmdShiftPToCtrlShiftP {
+    // cmd-shift-P should convert to Ctrl+Shift+P in Windows notation
+    keystroke = [self keystrokeWithKeyCode:35 modifiers:1179914 characters:@"P" charactersIgnoringModifiers:@"p"];
+    XCTAssertEqualObjects([eventTransformer transformedValueToWindowsNotation:keystroke], @"Ctrl+Shift+P");
+}
+
+- (void)test_windowsNotation_convertsOptAToAltA {
+    // opt-A should convert to Alt+A in Windows notation
+    keystroke = [self keystrokeWithKeyCode:0 modifiers:524576 characters:@"å" charactersIgnoringModifiers:@"a"];
+    XCTAssertEqualObjects([eventTransformer transformedValueToWindowsNotation:keystroke], @"Alt+A");
+}
+
+- (void)test_windowsNotation_convertsCmdOptIToCtrlAltI {
+    // cmd-opt-I should convert to Ctrl+Alt+I in Windows notation
+    keystroke = [self keystrokeWithKeyCode:34 modifiers:1573160 characters:@"ˆ" charactersIgnoringModifiers:@"i"];
+    XCTAssertEqualObjects([eventTransformer transformedValueToWindowsNotation:keystroke], @"Ctrl+Alt+I");
+}
+
+- (void)test_windowsNotation_convertsArrowKeys {
+    // Up arrow should convert to Up in Windows notation
+    keystroke = [self keystrokeWithKeyCode:126 modifiers:0 characters:@"" charactersIgnoringModifiers:@""];
+    XCTAssertEqualObjects([eventTransformer transformedValueToWindowsNotation:keystroke], @"Up");
+}
+
+- (void)test_windowsNotation_convertsFunctionKeys {
+    // F1 should remain F1 in Windows notation
+    keystroke = [self keystrokeWithKeyCode:122 modifiers:8388864 characters:@"" charactersIgnoringModifiers:@""];
+    XCTAssertEqualObjects([eventTransformer transformedValueToWindowsNotation:keystroke], @"F1");
+}
+
+- (void)test_windowsNotation_convertsShiftTab {
+    // shift-tab should convert to Shift+Tab in Windows notation
+    keystroke = [self keystrokeWithKeyCode:48 modifiers:131330 characters:[NSString stringWithFormat:@"%C", 0x00000019] charactersIgnoringModifiers:[NSString stringWithFormat:@"%C", 0x00000019]];
+    XCTAssertEqualObjects([eventTransformer transformedValueToWindowsNotation:keystroke], @"Shift+Tab");
+}
+
 @end


### PR DESCRIPTION
Implements a new feature to display pressed shortcuts in both macOS and Windows notation simultaneously. When enabled, keystrokes are shown side-by-side (e.g., "⌘C  │  Ctrl+C").

Changes:
- Add transformedValueToWindowsNotation: method to KCEventTransformer
  - Converts macOS modifier symbols to Windows text format
  - Maps ⌘/⌃ → Ctrl, ⌥ → Alt, ⇧ → Shift
  - Converts special keys (arrows, F-keys, etc.) to Windows equivalents

- Extend KCDefaultVisualizer to support dual notation display
  - Add default.showDualNotation UserDefaults key (default: NO)
  - Modify addKeystroke: to generate both notations when enabled
  - Display format: "macOS notation  │  Windows notation"

- Add preferences UI checkbox programmatically
  - KCDefaultVisualizerPreferencesView creates checkbox in awakeFromNib
  - Checkbox bound to UserDefaults for automatic persistence

- Add comprehensive unit tests
  - Test Windows notation conversion for various shortcuts
  - Verify correct modifier mapping and special key handling

The feature is disabled by default for backward compatibility.