### PR TITLE
feat: show modifier-only keypresses in visualizer

### DIFF
--- a/keycastr/KCDefaultVisualizer.h
+++ b/keycastr/KCDefaultVisualizer.h
@@ -79,6 +79,7 @@
 - (void)addKeystroke:(KCKeystroke *)keystroke;
 - (void)addMouseEvent:(KCMouseEvent *)mouseEvent;
 - (void)addRunningAnimation:(KCBezelAnimation *)animation;
+- (void)appendString:(NSString *)string;
 
 - (instancetype)init;
 
@@ -102,6 +103,7 @@ typedef NS_ENUM(NSInteger, KCDefaultVisualizerDisplayOption) {
 @interface KCDefaultVisualizer : KCVisualizer <KCVisualizer>
 {
 	KCDefaultVisualizerWindow* visualizerWindow;
+	NSEventModifierFlags _previousModifierFlags;
 }
 
 @property (nonatomic, assign) IBOutlet KCDefaultVisualizerPreferencesView *preferencesView;

--- a/keycastr/KCDefaultVisualizer.m
+++ b/keycastr/KCDefaultVisualizer.m
@@ -176,7 +176,30 @@ static const CGFloat kKCDefaultBezelPadding = 10.0;
 
 - (void)noteFlagsChanged:(NSEventModifierFlags)flags
 {
-    // no-op; future option to display or otherwise react to bare modifier keypresses
+    NSEventModifierFlags newlyPressed = flags & ~_previousModifierFlags;
+    _previousModifierFlags = flags;
+
+    if (newlyPressed == 0)
+        return;
+
+    BOOL isCommandModifier = (newlyPressed & (NSEventModifierFlagCommand | NSEventModifierFlagControl)) != 0;
+
+    if (!isCommandModifier && [self shouldOnlyDisplayCommandKeys])
+        return;
+
+    NSMutableString *displayString = [NSMutableString string];
+
+    if (newlyPressed & NSEventModifierFlagControl)
+        [displayString appendString:@"\xe2\x8c\x83"];
+    if (newlyPressed & NSEventModifierFlagOption)
+        [displayString appendString:@"\xe2\x8c\xa5"];
+    if (newlyPressed & NSEventModifierFlagShift)
+        [displayString appendString:@"\xe2\x87\xa7"];
+    if (newlyPressed & NSEventModifierFlagCommand)
+        [displayString appendString:@"\xe2\x8c\x98"];
+
+    if (displayString.length > 0)
+        [visualizerWindow appendString:displayString];
 }
 
 + (NSDictionary<NSString *, NSObject *> *)visualizerDefaults


### PR DESCRIPTION
## Problem

Pressing a modifier key alone (⌘, ⇧, ⌥, ⌃) showed nothing. Only combos like ⌘E worked.

This is because macOS fires `kCGEventFlagsChanged` for modifier-only presses instead of `kCGEventKeyDown`. KeyCastr already captured these events but `noteFlagsChanged:` was a no-op.

## Fix

Implement `noteFlagsChanged:` to detect newly pressed modifiers and display their glyphs. Respects the existing "Command Keys Only" display mode.