### PR TITLE
Add customizable mouse-click effects with new "Mouse" preferences tab

### DIFF
--- a/keycastr/KCAppController.h
+++ b/keycastr/KCAppController.h
@@ -30,6 +30,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+@class KCMouseEventVisualizer;
 @protocol KCVisualizer;
 
 @interface KCAppController : NSObject <NSApplicationDelegate>
@@ -56,5 +57,9 @@
 
 - (NSString *)currentMouseDisplayOptionName;
 - (void)setCurrentMouseDisplayOptionName:(NSString *)displayOptionName;
+
+- (NSArray *)availableMouseEffectNames;
+
+- (KCMouseEventVisualizer *)mouseEventVisualizer;
 
 @end

--- a/keycastr/KCAppController.m
+++ b/keycastr/KCAppController.m
@@ -33,6 +33,7 @@
 #import <Quartz/Quartz.h>
 #import <ShortcutRecorder/ShortcutRecorder.h>
 #import "KCAppController.h"
+#import "KCColorValueTransformer.h"
 #import "KCEventTap.h"
 #import "KCKeystroke.h"
 #import "KCMouseEventVisualizer.h"
@@ -215,6 +216,13 @@ static NSInteger kKCPrefDisplayIconInDock = 0x02;
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     [KCUserDefaultsMigration performMigration:userDefaults];
 
+    if (@available(macOS 10.14, *)) {
+        if ([NSValueTransformer valueTransformerForName:NSStringFromClass([KCColorValueTransformer class])] == nil) {
+            [NSValueTransformer setValueTransformer:[[KCColorValueTransformer alloc] init]
+                                            forName:NSStringFromClass([KCColorValueTransformer class])];
+        }
+    }
+
     KeyCombo keyCombo;
     keyCombo.code = 40;
     keyCombo.flags = NSEventModifierFlagControl | NSEventModifierFlagOption | NSEventModifierFlagCommand;
@@ -234,6 +242,7 @@ static NSInteger kKCPrefDisplayIconInDock = 0x02;
     }
     
     [defaults addEntriesFromDictionary:appDefaults];
+    [defaults addEntriesFromDictionary:[KCMouseEventVisualizer defaultPreferences]];
     [userDefaults registerDefaults:defaults];
 }
 
@@ -419,6 +428,10 @@ static NSInteger kKCPrefDisplayIconInDock = 0x02;
 
 - (NSArray *)availableMouseDisplayOptionNames {
     return mouseEventVisualizer.mouseDisplayOptionNames;
+}
+
+- (NSArray *)availableMouseEffectNames {
+    return mouseEventVisualizer.mouseEffectNames;
 }
 
 - (NSString *)currentMouseDisplayOptionName {

--- a/keycastr/KCMouseEventVisualizer.h
+++ b/keycastr/KCMouseEventVisualizer.h
@@ -26,10 +26,17 @@
 //  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-#import <Foundation/Foundation.h>
+#import <Cocoa/Cocoa.h>
 
 @class KCMouseEvent;
 @class KCMouseEventVisualizer;
+
+extern NSString * const kKCMouseEffectKey;
+extern NSString * const kKCMouseEffectColor1Key;
+extern NSString * const kKCMouseEffectColor2Key;
+extern NSString * const kKCMouseEffectDurationKey;
+extern NSString * const kKCMouseEffectDensityKey;
+extern NSString * const kKCMouseEffectDiameterKey;
 
 #pragma mark - KCMouseDisplayOptionsProvider
 
@@ -38,6 +45,9 @@
 @property (nonatomic, strong, readonly) NSArray<NSString *> *mouseDisplayOptionNames;
 @property (nonatomic, strong) NSString *currentMouseDisplayOptionName;
 @property (nonatomic, assign) NSInteger selectedMouseDisplayOptionIndex;
+
+@property (nonatomic, strong, readonly) NSArray<NSString *> *mouseEffectNames;
+@property (nonatomic, strong) NSString *currentMouseEffectName;
 
 @end
 
@@ -56,5 +66,7 @@
 @property (nonatomic, weak) id<KCMouseEventVisualizerDelegate> delegate;
 
 - (void)noteMouseEvent:(KCMouseEvent *)mouseEvent;
+
++ (NSDictionary<NSString *, id> *)defaultPreferences;
 
 @end

--- a/keycastr/KCMouseEventVisualizer.m
+++ b/keycastr/KCMouseEventVisualizer.m
@@ -36,9 +36,32 @@
 #import "NSUserDefaults+Utility.h"
 #import "KCKeycastrEvent.h"
 
-static CGFloat const kKCMouseVisualizerRadius = 22.0;
+NSString * const kKCMouseEffectKey = @"mouse.effect";
+NSString * const kKCMouseEffectColor1Key = @"mouse.effectColor1";
+NSString * const kKCMouseEffectColor2Key = @"mouse.effectColor2";
+NSString * const kKCMouseEffectDurationKey = @"mouse.effectDuration";
+NSString * const kKCMouseEffectDensityKey = @"mouse.effectDensity";
+NSString * const kKCMouseEffectDiameterKey = @"mouse.effectDiameter";
+
+static NSString *kKCMouseVisualizerDisplayOptionKey = @"mouse.displayOption";
+
+static NSString * const kKCMouseEffectHalo = @"Halo";
+static NSString * const kKCMouseEffectBlur = @"Blur";
+static NSString * const kKCMouseEffectHaloAndBlur = @"Halo + Blur";
+static NSString * const kKCMouseEffectDroplet = @"Droplet";
+
+// Default base diameter (the halo circle, blur core, droplet ring at scale=1) and the upper bound
+// the slider exposes — the visualizer window is sized once based on the upper bound, so any
+// in-range diameter at any scale fits without clipping.
+static CGFloat const kKCMouseEffectDefaultDiameter = 44.0;
+static CGFloat const kKCMouseEffectMaxDiameter = 160.0;
+static CGFloat const kKCMouseEffectMaxScale = 3.0;
+static CGFloat const kKCMouseEffectDefaultDensity = 2.0;
+static NSInteger const kKCDropletRingCount = 3;
 
 @interface KCMouseVisualizerWindow : NSWindow
+
+@property (nonatomic, copy) NSString *currentEffect;
 
 - (void)updateWithMouseEvent:(KCMouseEvent *)event;
 
@@ -49,15 +72,29 @@ static CGFloat const kKCMouseVisualizerRadius = 22.0;
 @interface KCMouseEventVisualizer ()
 
 @property (nonatomic, strong) NSArray<NSString *> *mouseDisplayOptionNames;
+@property (nonatomic, strong) NSArray<NSString *> *mouseEffectNames;
 @property (nonatomic, strong) KCMouseVisualizerWindow *window;
 
 @end
 
-@implementation KCMouseEventVisualizer 
+@implementation KCMouseEventVisualizer
 
 @synthesize selectedMouseDisplayOptionIndex = _selectedMouseDisplayOptionIndex;
 
-static NSString *kKCMouseVisualizerDisplayOptionKey = @"mouse.displayOption";
++ (NSDictionary<NSString *, id> *)defaultPreferences {
+    // Defaults are fully opaque so NSColorWell displays a clean swatch (its diagonal "transparency"
+    // indicator only appears when alpha < 1). Effect-time alpha is applied via animation opacity.
+    NSColor *defaultColor1 = [NSColor colorWithCalibratedRed:0.2 green:0.6 blue:1.0 alpha:1.0];
+    NSColor *defaultColor2 = [NSColor colorWithCalibratedRed:0.4 green:0.7 blue:1.0 alpha:1.0];
+    return @{
+        kKCMouseEffectKey: kKCMouseEffectHalo,
+        kKCMouseEffectDurationKey: @0.8,
+        kKCMouseEffectDensityKey: @(kKCMouseEffectDefaultDensity),
+        kKCMouseEffectDiameterKey: @(kKCMouseEffectDefaultDiameter),
+        kKCMouseEffectColor1Key: [NSKeyedArchiver archivedDataWithRootObject:defaultColor1 requiringSecureCoding:NO error:NULL],
+        kKCMouseEffectColor2Key: [NSKeyedArchiver archivedDataWithRootObject:defaultColor2 requiringSecureCoding:NO error:NULL],
+    };
+}
 
 - (instancetype)init {
     if (!(self = [super init])) {
@@ -70,6 +107,11 @@ static NSString *kKCMouseVisualizerDisplayOptionKey = @"mouse.displayOption";
             @"With Pointer and Visualizer"
     ];
 
+    _mouseEffectNames = @[kKCMouseEffectHalo,
+                          kKCMouseEffectBlur,
+                          kKCMouseEffectHaloAndBlur,
+                          kKCMouseEffectDroplet];
+
     self.selectedMouseDisplayOptionIndex = [NSUserDefaults.standardUserDefaults integerForKey:kKCMouseVisualizerDisplayOptionKey];
 
     return self;
@@ -81,12 +123,14 @@ static NSString *kKCMouseVisualizerDisplayOptionKey = @"mouse.displayOption";
 
 - (void)createWindow {
     if (NSApp == nil) return;
-    
-    CGFloat diameter = 2 * kKCMouseVisualizerRadius;
-    _window = [[KCMouseVisualizerWindow alloc] initWithContentRect:NSMakeRect(0, 0, diameter, diameter)
+
+    // Sized for the worst-case diameter at max scale plus a small buffer for stroke/shadow overflow.
+    CGFloat side = kKCMouseEffectMaxDiameter * kKCMouseEffectMaxScale + 40.0;
+    _window = [[KCMouseVisualizerWindow alloc] initWithContentRect:NSMakeRect(0, 0, side, side)
                                                          styleMask:NSWindowStyleMaskBorderless
                                                            backing:NSBackingStoreBuffered
                                                              defer:NO];
+    _window.currentEffect = self.currentMouseEffectName;
     [_window orderFrontRegardless];
 }
 
@@ -145,14 +189,31 @@ static NSString *kKCMouseVisualizerDisplayOptionKey = @"mouse.displayOption";
     }
 }
 
+- (NSString *)currentMouseEffectName {
+    NSString *stored = [[NSUserDefaults standardUserDefaults] stringForKey:kKCMouseEffectKey];
+    if ([self.mouseEffectNames containsObject:stored]) {
+        return stored;
+    }
+    return kKCMouseEffectHalo;
+}
+
+- (void)setCurrentMouseEffectName:(NSString *)name {
+    if (![self.mouseEffectNames containsObject:name]) {
+        return;
+    }
+    [[NSUserDefaults standardUserDefaults] setObject:name forKey:kKCMouseEffectKey];
+    _window.currentEffect = name;
+}
+
 @end
 
 #pragma mark - KCMouseVisualizerWindow
 
 @interface KCMouseVisualizerWindow ()
 
-@property (nonatomic, strong) CAShapeLayer *circle;
-@property (nonatomic, strong) CABasicAnimation *animation;
+@property (nonatomic, strong) CAShapeLayer *haloLayer;
+@property (nonatomic, strong) CALayer *blurLayer;
+@property (nonatomic, strong) NSArray<CAShapeLayer *> *dropletLayers;
 
 @end
 
@@ -164,120 +225,323 @@ static NSString *kKCMouseVisualizerDisplayOptionKey = @"mouse.displayOption";
 
     [self setLevel:NSScreenSaverWindowLevel];
     [self setOpaque:NO];
-
+    [self setIgnoresMouseEvents:YES];
     [self setBackgroundColor:[NSColor clearColor]];
     [self setAlphaValue:1];
-
     [self setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces];
 
-    // TODO: this should be its own color config.
-    [[NSUserDefaultsController sharedUserDefaultsController] addObserver:self forKeyPath:@"values.default.bezelColor" options:NSKeyValueObservingOptionNew context:NULL];
+    self.contentView.wantsLayer = YES;
+
+    NSUserDefaultsController *udc = [NSUserDefaultsController sharedUserDefaultsController];
+    for (NSString *key in [self observedKeys]) {
+        [udc addObserver:self forKeyPath:[@"values." stringByAppendingString:key] options:0 context:NULL];
+    }
 
     return self;
 }
 
+- (NSArray<NSString *> *)observedKeys {
+    return @[kKCMouseEffectColor1Key,
+             kKCMouseEffectColor2Key,
+             kKCMouseEffectKey,
+             kKCMouseEffectDensityKey,
+             kKCMouseEffectDiameterKey];
+}
+
 - (void)dealloc {
-    [[NSUserDefaultsController sharedUserDefaultsController] removeObserver:self forKeyPath:@"values.default.bezelColor"];
+    NSUserDefaultsController *udc = [NSUserDefaultsController sharedUserDefaultsController];
+    for (NSString *key in [self observedKeys]) {
+        [udc removeObserver:self forKeyPath:[@"values." stringByAppendingString:key]];
+    }
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context {
-    if ([keyPath isEqualToString:@"values.default.bezelColor"]) {
-        [self.circle removeFromSuperlayer];
-        self.circle = nil;
+    [self tearDownLayers];
+    if ([keyPath hasSuffix:kKCMouseEffectKey]) {
+        self.currentEffect = [[NSUserDefaults standardUserDefaults] stringForKey:kKCMouseEffectKey];
     }
 }
 
-- (void)updateWithMouseEvent:(KCMouseEvent *)event {
-    if (!self.circle) {
-        self.circle = [CAShapeLayer layer];
-
-        CGFloat diameter = 2 * kKCMouseVisualizerRadius;
-        CGFloat lineWidth = 2.0;
-        NSBezierPath *path = [NSBezierPath bezierPathWithRoundedRect:NSMakeRect(lineWidth, lineWidth, diameter - 2 * lineWidth, diameter - 2 * lineWidth)
-                                                             xRadius:kKCMouseVisualizerRadius
-                                                             yRadius:kKCMouseVisualizerRadius];
-        CGMutablePathRef pathRef = [self newCGPathWithBezierPath:path];
-        self.circle.path = pathRef;
-        CGPathRelease(pathRef);
-
-        NSColor *bezelColor = [[NSUserDefaults standardUserDefaults] colorForKey:@"default.bezelColor"];
-        self.circle.strokeColor = bezelColor.CGColor;
-
-        self.circle.fillColor = NSColor.clearColor.CGColor;
-        self.circle.lineWidth = lineWidth;
-        self.circle.opacity = 0.0;
-
-        [self.contentView.layer addSublayer:self.circle];
+- (void)tearDownLayers {
+    [self.haloLayer removeFromSuperlayer];
+    self.haloLayer = nil;
+    [self.blurLayer removeFromSuperlayer];
+    self.blurLayer = nil;
+    for (CAShapeLayer *ring in self.dropletLayers) {
+        [ring removeFromSuperlayer];
     }
+    self.dropletLayers = nil;
+}
+
+#pragma mark - Color/Pref accessors
+
+- (NSColor *)effectColor1 {
+    NSColor *c = [[NSUserDefaults standardUserDefaults] colorForKey:kKCMouseEffectColor1Key];
+    return c ?: [NSColor colorWithCalibratedRed:0.2 green:0.6 blue:1.0 alpha:0.85];
+}
+
+- (NSColor *)effectColor2 {
+    NSColor *c = [[NSUserDefaults standardUserDefaults] colorForKey:kKCMouseEffectColor2Key];
+    return c ?: [NSColor colorWithCalibratedRed:0.4 green:0.7 blue:1.0 alpha:0.45];
+}
+
+- (CGFloat)effectDuration {
+    double d = [[NSUserDefaults standardUserDefaults] doubleForKey:kKCMouseEffectDurationKey];
+    if (d <= 0.0) d = 0.5;
+    return d;
+}
+
+- (CGFloat)effectDensity {
+    double d = [[NSUserDefaults standardUserDefaults] doubleForKey:kKCMouseEffectDensityKey];
+    if (d <= 0.0) d = kKCMouseEffectDefaultDensity;
+    return d;
+}
+
+- (CGFloat)effectRadius {
+    double d = [[NSUserDefaults standardUserDefaults] doubleForKey:kKCMouseEffectDiameterKey];
+    if (d <= 0.0) d = kKCMouseEffectDefaultDiameter;
+    return d / 2.0;
+}
+
+- (NSString *)resolvedEffect {
+    NSString *e = self.currentEffect;
+    if ([@[kKCMouseEffectHalo, kKCMouseEffectBlur, kKCMouseEffectHaloAndBlur, kKCMouseEffectDroplet] containsObject:e]) {
+        return e;
+    }
+    return kKCMouseEffectHalo;
+}
+
+- (NSPoint)windowCenter {
+    NSSize size = self.frame.size;
+    return NSMakePoint(size.width / 2.0, size.height / 2.0);
+}
+
+#pragma mark - Event handling
+
+- (void)updateWithMouseEvent:(KCMouseEvent *)event {
+    NSString *effect = [self resolvedEffect];
 
     switch (event.type) {
         case NSEventTypeLeftMouseDown:
         case NSEventTypeRightMouseDown:
         case NSEventTypeOtherMouseDown: {
-            self.circle.opacity = 1.0;
-
-            if (self.animation == nil) {
-                self.animation = [CABasicAnimation animationWithKeyPath:@"opacity"];
-                self.animation.fromValue = @1.0;
-                self.animation.toValue = @0.0;
-            }
-            // fall through
+            [self centerOnEvent:event];
+            [self triggerEffect:effect];
+            break;
         }
         case NSEventTypeLeftMouseDragged:
         case NSEventTypeRightMouseDragged:
         case NSEventTypeOtherMouseDragged: {
-            NSPoint origin = NSMakePoint(event.locationInWindow.x - kKCMouseVisualizerRadius,
-                                         event.locationInWindow.y - kKCMouseVisualizerRadius);
-            [self setFrameOrigin:origin];
-
+            // Halo follows the cursor while held; the ripple/blur effects stay anchored at the click site.
+            if ([effect isEqualToString:kKCMouseEffectHalo] || [effect isEqualToString:kKCMouseEffectHaloAndBlur]) {
+                [self centerOnEvent:event];
+            }
             break;
         }
-
         case NSEventTypeLeftMouseUp:
         case NSEventTypeRightMouseUp:
         case NSEventTypeOtherMouseUp: {
-            if (self.animation) {
-                [self.circle addAnimation:self.animation forKey:@"opacityAnimation"];
-                self.animation = nil;
+            if ([effect isEqualToString:kKCMouseEffectHalo] || [effect isEqualToString:kKCMouseEffectHaloAndBlur]) {
+                [self fadeHalo];
             }
-            self.circle.opacity = 0.0;
-
             break;
         }
-
         default:
             break;
     }
 }
 
-- (CGMutablePathRef)newCGPathWithBezierPath:(NSBezierPath *)path {
-    CGMutablePathRef cgPath = CGPathCreateMutable();
-    NSInteger count = [path elementCount];
+- (void)centerOnEvent:(KCMouseEvent *)event {
+    NSPoint c = [self windowCenter];
+    NSPoint origin = NSMakePoint(event.locationInWindow.x - c.x,
+                                 event.locationInWindow.y - c.y);
+    [self setFrameOrigin:origin];
+}
 
-    for (NSInteger i = 0; i < count; i++) {
-        NSPoint points[3];
-        switch ([path elementAtIndex:i associatedPoints:points]) {
-            case NSBezierPathElementMoveTo: {
-                CGPathMoveToPoint(cgPath, NULL, points[0].x, points[0].y);
-                break;
-            }
-            case NSBezierPathElementLineTo: {
-                CGPathAddLineToPoint(cgPath, NULL, points[0].x, points[0].y);
-                break;
-            }
-            case NSBezierPathElementCurveTo: {
-                CGPathAddCurveToPoint(cgPath, NULL, points[0].x, points[0].y, points[1].x, points[1].y, points[2].x, points[2].y);
-                break;
-            }
-            case NSBezierPathElementClosePath: {
-                CGPathCloseSubpath(cgPath);
-                break;
-            }
-            default:
-                NSAssert(0, @"Invalid NSBezierPathElement");
-        }
+- (void)triggerEffect:(NSString *)effect {
+    if ([effect isEqualToString:kKCMouseEffectHalo]) {
+        [self showHaloPersistent];
+    } else if ([effect isEqualToString:kKCMouseEffectBlur]) {
+        [self runBlurAnimation];
+    } else if ([effect isEqualToString:kKCMouseEffectHaloAndBlur]) {
+        [self showHaloPersistent];
+        [self runBlurAnimation];
+    } else if ([effect isEqualToString:kKCMouseEffectDroplet]) {
+        [self runDropletAnimation];
     }
-    return cgPath;
+}
+
+#pragma mark - Halo
+
+- (void)ensureHaloLayer {
+    if (self.haloLayer) return;
+
+    CAShapeLayer *layer = [CAShapeLayer layer];
+    CGFloat radius = [self effectRadius];
+    CGFloat diameter = 2 * radius;
+    CGFloat lineWidth = [self effectDensity];
+    NSPoint c = [self windowCenter];
+    CGRect rect = CGRectMake(c.x - radius + lineWidth,
+                             c.y - radius + lineWidth,
+                             diameter - 2 * lineWidth,
+                             diameter - 2 * lineWidth);
+    layer.path = CGPathCreateWithEllipseInRect(rect, NULL);
+    layer.strokeColor = [self effectColor1].CGColor;
+    layer.fillColor = NSColor.clearColor.CGColor;
+    layer.lineWidth = lineWidth;
+    layer.opacity = 0.0;
+
+    [self.contentView.layer addSublayer:layer];
+    self.haloLayer = layer;
+}
+
+- (void)showHaloPersistent {
+    [self ensureHaloLayer];
+    // Wrap in a transaction with implicit animations disabled — otherwise CALayer's default
+    // 0.25s implicit animation on `opacity` produces a soft fade-in that visibly conflicts
+    // with the explicit fade-out animation triggered on mouseUp, reading as a double blink.
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    self.haloLayer.strokeColor = [self effectColor1].CGColor;
+    [self.haloLayer removeAllAnimations];
+    self.haloLayer.opacity = 1.0;
+    [CATransaction commit];
+}
+
+- (void)fadeHalo {
+    if (!self.haloLayer) return;
+    CABasicAnimation *fade = [CABasicAnimation animationWithKeyPath:@"opacity"];
+    fade.fromValue = @1.0;
+    fade.toValue = @0.0;
+    fade.duration = [self effectDuration];
+    [self.haloLayer addAnimation:fade forKey:@"opacityFade"];
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    self.haloLayer.opacity = 0.0;
+    [CATransaction commit];
+}
+
+#pragma mark - Blur
+
+- (void)runBlurAnimation {
+    [self.blurLayer removeFromSuperlayer];
+
+    CGFloat radius = [self effectRadius];
+    CGFloat diameter = 2 * radius;
+    NSPoint c = [self windowCenter];
+    CGRect bounds = CGRectMake(0, 0, diameter, diameter);
+
+    // Soft-edged disk: a radial gradient layer fading from the chosen color to transparent at the rim.
+    // Density controls how much of the radius stays fully opaque before the gradient starts fading.
+    CAGradientLayer *layer = [CAGradientLayer layer];
+    layer.type = kCAGradientLayerRadial;
+    NSColor *color = [self effectColor2];
+    NSColor *colorAtCenter = [color colorWithAlphaComponent:color.alphaComponent];
+    NSColor *colorAtEdge = [color colorWithAlphaComponent:0.0];
+    CGFloat density = [self effectDensity];
+    // Map density 1..12 → opaque core fraction 0..0.75 of the radius.
+    CGFloat opaqueCore = MAX(0.0, MIN(0.85, (density - 1.0) / 14.0));
+    layer.colors = @[(__bridge id)colorAtCenter.CGColor, (__bridge id)colorAtCenter.CGColor, (__bridge id)colorAtEdge.CGColor];
+    layer.locations = @[@0.0, @(opaqueCore), @1.0];
+    layer.startPoint = CGPointMake(0.5, 0.5);
+    layer.endPoint = CGPointMake(1.0, 1.0);
+    layer.bounds = bounds;
+    layer.position = CGPointMake(c.x, c.y);
+    layer.opacity = 0.0;
+
+    [self.contentView.layer addSublayer:layer];
+    self.blurLayer = layer;
+
+    CGFloat duration = [self effectDuration];
+
+    CABasicAnimation *scale = [CABasicAnimation animationWithKeyPath:@"transform.scale"];
+    scale.fromValue = @0.6;
+    scale.toValue = @(kKCMouseEffectMaxScale * 0.7);
+    scale.duration = duration;
+    scale.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
+
+    CAKeyframeAnimation *opacity = [CAKeyframeAnimation animationWithKeyPath:@"opacity"];
+    opacity.values = @[@0.0, @1.0, @0.0];
+    opacity.keyTimes = @[@0.0, @0.2, @1.0];
+    opacity.duration = duration;
+
+    CAAnimationGroup *group = [CAAnimationGroup animation];
+    group.animations = @[scale, opacity];
+    group.duration = duration;
+    group.removedOnCompletion = YES;
+
+    [layer addAnimation:group forKey:@"blurExpand"];
+}
+
+#pragma mark - Droplet
+
+- (void)runDropletAnimation {
+    for (CAShapeLayer *ring in self.dropletLayers) {
+        [ring removeFromSuperlayer];
+    }
+
+    CGFloat duration = [self effectDuration];
+    CGFloat stagger = duration / (kKCDropletRingCount + 1);
+    NSPoint c = [self windowCenter];
+    NSColor *color = [self effectColor1];
+
+    NSMutableArray<CAShapeLayer *> *rings = [NSMutableArray array];
+    CGFloat radius = [self effectRadius];
+    CGFloat diameter = 2 * radius;
+    // Droplet rings read a bit thicker than halo at the same density.
+    CGFloat ringLineWidth = MAX(2.0, [self effectDensity] * 2.0);
+    for (NSInteger i = 0; i < kKCDropletRingCount; i++) {
+        CAShapeLayer *ring = [CAShapeLayer layer];
+        CGFloat lineWidth = ringLineWidth;
+        // Anchor the ring's center on the cursor so transform.scale grows from there
+        // instead of scaling around the parent layer's origin.
+        ring.bounds = CGRectMake(0, 0, diameter, diameter);
+        ring.position = CGPointMake(c.x, c.y);
+        ring.path = CGPathCreateWithEllipseInRect(CGRectMake(0, 0, diameter, diameter), NULL);
+        ring.fillColor = NSColor.clearColor.CGColor;
+        ring.strokeColor = color.CGColor;
+        ring.lineWidth = lineWidth;
+        ring.opacity = 0.0;
+        // Glow halo on both sides of the stroke so the ring reads as a soft wavefront, not a hard outline.
+        ring.shadowColor = color.CGColor;
+        ring.shadowOpacity = 0.9;
+        ring.shadowRadius = 6.0;
+        ring.shadowOffset = CGSizeZero;
+        ring.masksToBounds = NO;
+        [self.contentView.layer addSublayer:ring];
+        [rings addObject:ring];
+
+        CGFloat begin = stagger * i;
+        CGFloat ringDuration = duration - begin;
+        if (ringDuration < 0.1) ringDuration = 0.1;
+
+        CABasicAnimation *scale = [CABasicAnimation animationWithKeyPath:@"transform.scale"];
+        scale.fromValue = @0.2;
+        scale.toValue = @(kKCMouseEffectMaxScale);
+        scale.duration = ringDuration;
+        scale.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
+
+        // Slower opacity ramp + lower peak so the rings feel like a swell rather than a strobe.
+        CAKeyframeAnimation *opacity = [CAKeyframeAnimation animationWithKeyPath:@"opacity"];
+        opacity.values = @[@0.0, @0.65, @0.0];
+        opacity.keyTimes = @[@0.0, @0.4, @1.0];
+        opacity.duration = ringDuration;
+
+        // Thin the stroke as it expands so the ring dissipates into the background.
+        CABasicAnimation *width = [CABasicAnimation animationWithKeyPath:@"lineWidth"];
+        width.fromValue = @(lineWidth);
+        width.toValue = @(lineWidth * 0.3);
+        width.duration = ringDuration;
+
+        CAAnimationGroup *group = [CAAnimationGroup animation];
+        group.animations = @[scale, opacity, width];
+        group.duration = ringDuration;
+        group.beginTime = CACurrentMediaTime() + begin;
+        group.removedOnCompletion = YES;
+
+        [ring addAnimation:group forKey:@"ripple"];
+    }
+    self.dropletLayers = rings;
 }
 
 @end

--- a/keycastr/KCPrefsWindowController.h
+++ b/keycastr/KCPrefsWindowController.h
@@ -40,6 +40,10 @@
 	NSToolbar* toolbar;
 	NSMutableArray* preferenceViews;
 	NSInteger _selectedPreferencePane;
+	NSBox* _mouseEffectsBox;
+	CGFloat _mouseEffectsBoxOuterHeight;
+	NSView* _originalDisplayTab;
+	NSView* _displayWrapper;
 }
 
 -(void) changeVisualizerFrom:(id<KCVisualizer>)old to:(id<KCVisualizer>)new;

--- a/keycastr/KCPrefsWindowController.m
+++ b/keycastr/KCPrefsWindowController.m
@@ -29,7 +29,11 @@
 
 #import "KCPrefsWindowController.h"
 #import "KCAppController.h"
+#import "KCColorValueTransformer.h"
+#import "KCMouseEventVisualizer.h"
 #import "KCVisualizer.h"
+
+static CGFloat const kKCMouseEffectsBoxMargin = 12.0;
 
 @implementation KCPrefsWindowController
 
@@ -93,7 +97,7 @@
 	{
 		[[old preferencesView] removeFromSuperview];
 	}
-		
+
 	// we assume it's the second item in the array
 	NSView* view = [preferenceViews objectAtIndex:1];
 	NSView* subview = [[view subviews] objectAtIndex:0];
@@ -103,13 +107,267 @@
 	s.height += [subview frame].size.height * 2.0;
 	[view setFrameSize:s];
 	[view addSubview:prefView];
-	
+
 	if (_selectedPreferencePane == 1)
 	{
 		BOOL display = [prefsWindow isVisible];
 		NSRect newFrame = [self frameRectWithPin:NSZeroPoint andContentSize:s];
 		[prefsWindow setFrame:newFrame display:display animate:display];
 	}
+}
+
+#pragma mark - Mouse Effects controls
+
+// Layout constants — all dimensions are in points, all using absolute frames.
+static const CGFloat kKCRowHeight = 24.0;
+static const CGFloat kKCRowSpacing = 10.0;
+static const CGFloat kKCBoxTopPadding = 14.0;
+static const CGFloat kKCBoxBottomPadding = 14.0;
+static const CGFloat kKCLabelWidth = 170.0;
+static const CGFloat kKCLabelToControlGap = 8.0;
+static const CGFloat kKCInnerHorizontalPadding = 16.0;
+static const CGFloat kKCRowCount = 6;
+// NSBox with NSAtTop title position consumes ~22pt for the title bar at the top of its frame.
+static const CGFloat kKCBoxTitleReserve = 24.0;
+
+-(CGFloat) mouseEffectsContentHeight
+{
+	return kKCBoxTopPadding + kKCRowCount * kKCRowHeight + (kKCRowCount - 1) * kKCRowSpacing + kKCBoxBottomPadding;
+}
+
+-(CGFloat) mouseEffectsBoxHeight
+{
+	return [self mouseEffectsContentHeight] + kKCBoxTitleReserve;
+}
+
+-(NSTextField*) labelWithFrame:(NSRect)frame string:(NSString*)str
+{
+	NSTextField* label = [[[NSTextField alloc] initWithFrame:frame] autorelease];
+	[label setStringValue:str];
+	[label setEditable:NO];
+	[label setBezeled:NO];
+	[label setDrawsBackground:NO];
+	[label setSelectable:NO];
+	[label setAlignment:NSTextAlignmentRight];
+	return label;
+}
+
+-(NSColorWell*) colorWellWithFrame:(NSRect)frame forKey:(NSString*)defaultsKey
+{
+	NSColorWell* well = [[[NSColorWell alloc] initWithFrame:frame] autorelease];
+	NSDictionary* options = @{
+		NSValueTransformerNameBindingOption: NSStringFromClass([KCColorValueTransformer class]),
+	};
+	[well bind:NSValueBinding
+	  toObject:[NSUserDefaultsController sharedUserDefaultsController]
+   withKeyPath:[@"values." stringByAppendingString:defaultsKey]
+	   options:options];
+	return well;
+}
+
+-(NSBox*) buildMouseEffectsBoxWithWidth:(CGFloat)width
+{
+	CGFloat boxHeight = [self mouseEffectsBoxHeight];
+	NSBox* box = [[[NSBox alloc] initWithFrame:NSMakeRect(0, 0, width, boxHeight)] autorelease];
+	[box setTitle:@"Mouse Effect"];
+	[box setBoxType:NSBoxPrimary];
+	[box setTitlePosition:NSAtTop];
+
+	NSView* content = [box contentView];
+	NSRect contentFrame = [content frame];
+	CGFloat innerWidth = contentFrame.size.width - 2 * kKCInnerHorizontalPadding;
+	CGFloat controlX = kKCInnerHorizontalPadding + kKCLabelWidth + kKCLabelToControlGap;
+	CGFloat controlWidth = innerWidth - kKCLabelWidth - kKCLabelToControlGap;
+	if (controlWidth < 120) controlWidth = 120;
+
+	// Place rows top-to-bottom in Cocoa coordinates (y decreases as we go down).
+	CGFloat topY = contentFrame.size.height - kKCBoxTopPadding - kKCRowHeight;
+	CGFloat rowStride = kKCRowHeight + kKCRowSpacing;
+
+	NSRect (^labelRectAt)(NSInteger) = ^NSRect(NSInteger rowIndex) {
+		return NSMakeRect(kKCInnerHorizontalPadding, topY - rowIndex * rowStride, kKCLabelWidth, kKCRowHeight);
+	};
+	NSRect (^controlRectAt)(NSInteger) = ^NSRect(NSInteger rowIndex) {
+		return NSMakeRect(controlX, topY - rowIndex * rowStride, controlWidth, kKCRowHeight);
+	};
+
+	// Row 0: Mouse Effect popup
+	[content addSubview:[self labelWithFrame:labelRectAt(0) string:@"Mouse Effect:"]];
+	NSRect popupFrame = controlRectAt(0);
+	popupFrame.size.width = MIN(controlWidth, 200.0);
+	NSPopUpButton* popup = [[[NSPopUpButton alloc] initWithFrame:popupFrame pullsDown:NO] autorelease];
+	[popup bind:NSContentValuesBinding
+	   toObject:appController
+	withKeyPath:@"availableMouseEffectNames"
+		options:nil];
+	[popup bind:NSSelectedValueBinding
+	   toObject:[NSUserDefaultsController sharedUserDefaultsController]
+	withKeyPath:[@"values." stringByAppendingString:kKCMouseEffectKey]
+		options:nil];
+	[content addSubview:popup];
+
+	// Row 1: Mouse Effect Color 1
+	[content addSubview:[self labelWithFrame:labelRectAt(1) string:@"Mouse Effect Color 1:"]];
+	NSRect color1Frame = NSMakeRect(controlX, topY - 1 * rowStride, 60.0, kKCRowHeight);
+	[content addSubview:[self colorWellWithFrame:color1Frame forKey:kKCMouseEffectColor1Key]];
+
+	// Row 2: Mouse Effect Color 2
+	[content addSubview:[self labelWithFrame:labelRectAt(2) string:@"Mouse Effect Color 2:"]];
+	NSRect color2Frame = NSMakeRect(controlX, topY - 2 * rowStride, 60.0, kKCRowHeight);
+	[content addSubview:[self colorWellWithFrame:color2Frame forKey:kKCMouseEffectColor2Key]];
+
+	// Row 3: Density (line/core thickness)
+	[self addSliderRowToContent:content
+				   labelString:@"Mouse Effect Density:"
+					  labelRect:labelRectAt(3)
+					controlX:controlX
+					controlY:topY - 3 * rowStride
+				 controlWidth:controlWidth
+					 minValue:1.0
+					 maxValue:12.0
+				   defaultsKey:kKCMouseEffectDensityKey
+					  suffix:@""];
+
+	// Row 4: Diameter (outer extent of the effect)
+	[self addSliderRowToContent:content
+				   labelString:@"Mouse Effect Diameter:"
+					  labelRect:labelRectAt(4)
+					controlX:controlX
+					controlY:topY - 4 * rowStride
+				 controlWidth:controlWidth
+					 minValue:20.0
+					 maxValue:160.0
+				   defaultsKey:kKCMouseEffectDiameterKey
+					  suffix:@" pt"];
+
+	// Row 5: Duration
+	[self addSliderRowToContent:content
+				   labelString:@"Mouse Effect Duration:"
+					  labelRect:labelRectAt(5)
+					controlX:controlX
+					controlY:topY - 5 * rowStride
+				 controlWidth:controlWidth
+					 minValue:0.1
+					 maxValue:2.0
+				   defaultsKey:kKCMouseEffectDurationKey
+					  suffix:@" s"];
+
+	return box;
+}
+
+-(void) addSliderRowToContent:(NSView*)content
+				   labelString:(NSString*)labelStr
+					 labelRect:(NSRect)labelRect
+					  controlX:(CGFloat)controlX
+					  controlY:(CGFloat)controlY
+				  controlWidth:(CGFloat)controlWidth
+					  minValue:(double)minValue
+					  maxValue:(double)maxValue
+				   defaultsKey:(NSString*)defaultsKey
+						suffix:(NSString*)suffix
+{
+	[content addSubview:[self labelWithFrame:labelRect string:labelStr]];
+
+	CGFloat readoutWidth = 70.0;
+	CGFloat sliderWidth = controlWidth - readoutWidth - 8.0;
+	if (sliderWidth < 80) sliderWidth = 80;
+
+	NSSlider* slider = [[[NSSlider alloc] initWithFrame:NSMakeRect(controlX, controlY, sliderWidth, kKCRowHeight)] autorelease];
+	[slider setMinValue:minValue];
+	[slider setMaxValue:maxValue];
+	[slider bind:NSValueBinding
+		toObject:[NSUserDefaultsController sharedUserDefaultsController]
+	 withKeyPath:[@"values." stringByAppendingString:defaultsKey]
+		 options:@{NSContinuouslyUpdatesValueBindingOption: @YES}];
+	[content addSubview:slider];
+
+	NSTextField* field = [[[NSTextField alloc] initWithFrame:NSMakeRect(controlX + sliderWidth + 8.0, controlY, readoutWidth, kKCRowHeight)] autorelease];
+	[field setEditable:YES];
+	[field setBezeled:YES];
+	[field setBezelStyle:NSTextFieldRoundedBezel];
+	[field setDrawsBackground:YES];
+	[field setSelectable:YES];
+	[field setAlignment:NSTextAlignmentRight];
+	NSNumberFormatter* fmt = [[[NSNumberFormatter alloc] init] autorelease];
+	[fmt setMinimumFractionDigits:2];
+	[fmt setMaximumFractionDigits:2];
+	[fmt setMinimum:@(minValue)];
+	[fmt setMaximum:@(maxValue)];
+	if ([suffix length] > 0) {
+		[fmt setPositiveSuffix:suffix];
+	}
+	[field setFormatter:fmt];
+	[field bind:NSValueBinding
+	   toObject:[NSUserDefaultsController sharedUserDefaultsController]
+	withKeyPath:[@"values." stringByAppendingString:defaultsKey]
+		options:@{NSContinuouslyUpdatesValueBindingOption: @YES}];
+	[content addSubview:field];
+}
+
+-(NSView*) buildMouseEffectsTabContentView
+{
+	if (_mouseEffectsBox != nil) {
+		// Already built; reuse parent.
+		return [_mouseEffectsBox superview];
+	}
+
+	// Match the General/Display tabs' typical width so the prefs window doesn't visibly resize when switching to ours.
+	CGFloat tabWidth = 460.0;
+	if ([preferenceViews count] > 0) {
+		tabWidth = [[preferenceViews objectAtIndex:0] frame].size.width;
+	}
+
+	CGFloat boxWidth = tabWidth - 2 * kKCMouseEffectsBoxMargin;
+	NSBox* box = [self buildMouseEffectsBoxWithWidth:boxWidth];
+	CGFloat boxHeight = [box frame].size.height;
+
+	CGFloat tabHeight = boxHeight + 2 * kKCMouseEffectsBoxMargin;
+	NSView* contentView = [[[NSView alloc] initWithFrame:NSMakeRect(0, 0, tabWidth, tabHeight)] autorelease];
+
+	NSRect boxFrame = NSMakeRect(kKCMouseEffectsBoxMargin,
+								 kKCMouseEffectsBoxMargin,
+								 boxWidth,
+								 boxHeight);
+	[box setFrame:boxFrame];
+	[box setAutoresizingMask:NSViewWidthSizable];
+	[contentView addSubview:box];
+
+	_mouseEffectsBox = [box retain];
+	return contentView;
+}
+
+-(void) registerMouseEffectsTab
+{
+	if (_mouseEffectsBox != nil) return;
+
+	NSView* contentView = [self buildMouseEffectsTabContentView];
+	NSString* identifier = @"Mouse";
+	NSInteger tag = [preferenceViews count];
+
+	NSToolbarItem* item = [[[NSToolbarItem alloc] initWithItemIdentifier:identifier] autorelease];
+	[item setLabel:identifier];
+
+	NSImage* icon = nil;
+	if (@available(macOS 11.0, *)) {
+		icon = [NSImage imageWithSystemSymbolName:@"computermouse" accessibilityDescription:@"Mouse"];
+	}
+	if (icon == nil) {
+		icon = [NSImage imageNamed:NSImageNameComputer];
+	}
+	[item setImage:icon];
+	[item setTarget:self];
+	[item setAction:@selector(toolbarItemSelected:)];
+	[item setTag:tag];
+
+	// Place Mouse before the last existing identifier (Update) so the toolbar reads
+	// General | Display | Mouse | Update.  preferenceViews index (= tag) stays at the end.
+	NSUInteger insertIndex = [toolbarItemIdentifiers count];
+	if (insertIndex > 0) {
+		insertIndex -= 1;
+	}
+	[toolbarItemIdentifiers insertObject:identifier atIndex:insertIndex];
+	[toolbarItems setObject:item forKey:identifier];
+	[preferenceViews addObject:contentView];
 }
 
 -(void) visualizerChanged:(NSNotification*)notification
@@ -154,6 +412,9 @@
 		tag++;
 	}
 
+	// Append our programmatic "Mouse" tab before the toolbar is built so it shows up in the toolbar.
+	[self registerMouseEffectsTab];
+
 	toolbar = [[NSToolbar alloc] initWithIdentifier:@"KeyCastrToolbar"];
 	[toolbar setAllowsUserCustomization:NO];
 	[toolbar setAutosavesConfiguration:NO];
@@ -171,6 +432,7 @@
 	// fixup the dimensions of the Display preference pane based on the current visualizer
 	id<KCVisualizer> v = [appController currentVisualizer];
 	[self changeVisualizerFrom:nil to:v];
+
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(visualizerChanged:) name:@"KCVisualizerChanged" object:nil];
 	_selectedPreferencePane = 0;
 }
@@ -180,6 +442,9 @@
     [toolbarItems release];
     [toolbarItemIdentifiers release];
     [preferenceViews release];
+    [_mouseEffectsBox release];
+    [_originalDisplayTab release];
+    [_displayWrapper release];
     [super dealloc];
 }
 


### PR DESCRIPTION
Hi! KeyCastr user here, first contribution. I built this for my own use and figured I'd offer it upstream. Feel free to incorporate it, or not as you see fit. Full transparency: I did use a coding agent for the work, but it's fully functional.

## What this adds

A new "Mouse" preferences tab with four mouse-click visual effects (Halo, Blur, Halo + Blur, Droplet) and per-effect customization for color, density, diameter, and duration. The original Halo behavior is preserved as the default, just with its color decoupled from the keystroke bezel color.

**Demo:** https://www.loom.com/share/1a43df69bfbf4ce09d79115e62cc0696

## Design notes worth flagging for review

- **Added as a separate prefs tab rather than extending the Display tab:** I tried three approaches to graft the controls onto Display and each one collided with the existing tab's autoresize-mask layout — a new tab kept the Display tab pristine and avoided risk to the visualizer plugin pref injection. Feel free to move it back if you have a layout approach in mind.
- **Namespaced preferences:** All new prefs are namespaced under `mouse.*` keys; the existing `default.bezelColor` is no longer read by the mouse visualizer (its color is now `mouse.effectColor1`). I didn't add a migration — fresh installs get the new opaque defaults, existing users keep their bezel color for keystrokes and pick a new mouse color on first visit.
- **Programmatic UI:** UI is built programmatically rather than in `MainMenu.nib` so the binary nib stays untouched. Easier to review as text; downside is it's not editable in Interface Builder.
- **Tests:** No new tests. The existing `KCMouseEventVisualizerTests` still pass.

## Commit

Full technical breakdown is in the single commit message — file-by-file walkthrough of methods touched, KVO wiring, droplet anchor-point fix, etc. Worth reading before reviewing the diff.