### PR TITLE
Display mouse buttons in visualizer

### DIFF
--- a/keycastr/KCEventTransformer.m
+++ b/keycastr/KCEventTransformer.m
@@ -260,7 +260,35 @@ static NSString* kLeftTabString = @"\xe2\x87\xa4";
             [mutableResponse appendString:kShiftKeyString];
             needsShiftGlyph = NO;
         }
-        [mutableResponse appendString:@"🖱️"];
+
+        NSString *token;
+        switch (event.type) {
+            case NSEventTypeLeftMouseDown:
+            case NSEventTypeLeftMouseUp:
+            case NSEventTypeLeftMouseDragged:
+                token = @"LMB";
+                break;
+            case NSEventTypeRightMouseDown:
+            case NSEventTypeRightMouseUp:
+            case NSEventTypeRightMouseDragged:
+                token = @"RMB";
+                break;
+            case NSEventTypeOtherMouseDown:
+            case NSEventTypeOtherMouseUp:
+            case NSEventTypeOtherMouseDragged: {
+                NSInteger buttonNumber = ((KCMouseEvent *)event).buttonNumber;
+                if (buttonNumber == 2) {
+                    token = @"MMB";
+                } else {
+                    token = [NSString stringWithFormat:@"MB%ld", (long)(buttonNumber + 1)];
+                }
+                break;
+            }
+            default:
+                token = @"MB?";
+                break;
+        }
+        [mutableResponse appendString:token];
         return mutableResponse;
     }
     

--- a/keycastr/KCMouseEvent.h
+++ b/keycastr/KCMouseEvent.h
@@ -32,5 +32,6 @@
 @interface KCMouseEvent : KCKeycastrEvent
 
 @property (nonatomic, readonly) NSPoint locationInWindow;
+@property (nonatomic, readonly) NSInteger buttonNumber;
 
 @end

--- a/keycastr/KCMouseEvent.m
+++ b/keycastr/KCMouseEvent.m
@@ -38,6 +38,7 @@
     }
 
     _locationInWindow = event.locationInWindow;
+    _buttonNumber = event.buttonNumber;
 
     return self;
 }

--- a/keycastr/KCVisualizerTests/KCKeystrokeConversionTests.m
+++ b/keycastr/KCVisualizerTests/KCKeystrokeConversionTests.m
@@ -28,6 +28,7 @@
 #import <XCTest/XCTest.h>
 #import <KCVisualizer/KCKeystroke.h>
 #import <KCVisualizer/KCEventTransformer.h>
+#import "KCMouseEvent.h"
 
 /**
  NOTE: This is not a comprehensive set of tests, but serves as a sanity check for handling commands and whether to display or apply modifiers.
@@ -279,6 +280,52 @@
     // In order to avoid confusion, fall back to displaying the keycap.
     keystroke = [self keystrokeWithKeyCode:27 modifiers:1048840 characters:@"ß" charactersIgnoringModifiers:@"ß"];
     XCTAssertEqualObjects([keystroke convertToString], @"⌘ß");
+}
+
+#pragma mark - Mouse buttons
+
+- (KCMouseEvent *)mouseEventOfType:(NSEventType)type buttonNumber:(NSInteger)buttonNumber modifiers:(NSEventModifierFlags)modifiers {
+    KCMouseEvent *event = [[KCMouseEvent alloc] initWithNSEvent:nil];
+    [event setValue:@(type) forKey:@"type"];
+    [event setValue:@(buttonNumber) forKey:@"buttonNumber"];
+    [event setValue:@(modifiers) forKey:@"modifierFlags"];
+    return event;
+}
+
+- (void)test_KCMouseEvent_leftMouseDownIsLMB {
+    KCMouseEvent *event = [self mouseEventOfType:NSEventTypeLeftMouseDown buttonNumber:0 modifiers:0];
+    XCTAssertEqualObjects([eventTransformer transformedValue:event], @"LMB");
+}
+
+- (void)test_KCMouseEvent_rightMouseDownIsRMB {
+    KCMouseEvent *event = [self mouseEventOfType:NSEventTypeRightMouseDown buttonNumber:1 modifiers:0];
+    XCTAssertEqualObjects([eventTransformer transformedValue:event], @"RMB");
+}
+
+- (void)test_KCMouseEvent_middleMouseDownIsMMB {
+    KCMouseEvent *event = [self mouseEventOfType:NSEventTypeOtherMouseDown buttonNumber:2 modifiers:0];
+    XCTAssertEqualObjects([eventTransformer transformedValue:event], @"MMB");
+}
+
+- (void)test_KCMouseEvent_fourthButtonIsMB4 {
+    KCMouseEvent *event = [self mouseEventOfType:NSEventTypeOtherMouseDown buttonNumber:3 modifiers:0];
+    XCTAssertEqualObjects([eventTransformer transformedValue:event], @"MB4");
+}
+
+- (void)test_KCMouseEvent_fifthButtonIsMB5 {
+    KCMouseEvent *event = [self mouseEventOfType:NSEventTypeOtherMouseDown buttonNumber:4 modifiers:0];
+    XCTAssertEqualObjects([eventTransformer transformedValue:event], @"MB5");
+}
+
+- (void)test_KCMouseEvent_commandLeftClickShowsCommandLMB {
+    KCMouseEvent *event = [self mouseEventOfType:NSEventTypeLeftMouseDown buttonNumber:0 modifiers:NSEventModifierFlagCommand];
+    XCTAssertEqualObjects([eventTransformer transformedValue:event], @"⌘LMB");
+}
+
+- (void)test_KCMouseEvent_optionShiftRightClickShowsModifiersWithRMB {
+    NSEventModifierFlags modifiers = NSEventModifierFlagOption | NSEventModifierFlagShift;
+    KCMouseEvent *event = [self mouseEventOfType:NSEventTypeRightMouseDown buttonNumber:1 modifiers:modifiers];
+    XCTAssertEqualObjects([eventTransformer transformedValue:event], @"⌥⇧RMB");
 }
 
 @end


### PR DESCRIPTION
## What (https://github.com/keycastr/keycastr/issues/345)

When the "With Current Visualizer" mouse display option is enabled, the keystroke visualizer previously rendered every mouse click as a single "🖱️" glyph, so viewers couldn't tell which button was pressed.

This change makes `KCEventTransformer` emit a button-specific token instead:

| NSEvent type / buttonNumber | Token |
|---|---|
| Left mouse | `LMB` |
| Right mouse | `RMB` |
| Other mouse, buttonNumber 2 | `MMB` |
| Other mouse, buttonNumber ≥ 3 | `MB<N+1>` (1-indexed) |

Modifier prefixes still glue to the token, same as keystrokes: `⌘LMB`, `⌥⇧RMB`, etc.



## Scope

- Change is in the shared `KCEventTransformer`, so both the Default and Svelte visualizers pick up the new tokens automatically through, no per-visualizer code changes needed.
- The mouse-pointer circle visualizer (`KCMouseEventVisualizer`) is unchanged.
- Mouse-down only, matching existing behavior in `KCDefaultVisualizer.addMouseEvent:`.

## Implementation

  - Added `buttonNumber` to `KCMouseEvent`, captured from `NSEvent.buttonNumber` in `initWithNSEvent:`.
  - Replaced the hardcoded `🖱️` string in `KCEventTransformer.m` with a switch on `event.type` plus a `buttonNumber` lookup for the "other" cases.

## Demo

https://github.com/user-attachments/assets/ceb09018-3a9b-45f2-96b3-533eaa2cfe94

