### PR TITLE
Distinguish numeric keypad keys

### DIFF
--- a/keycastr/KCEventTransformer.m
+++ b/keycastr/KCEventTransformer.m
@@ -168,7 +168,7 @@ static NSString* kLeftTabString = @"\xe2\x87\xa4";
              UTF8("\xe2\x87\xa0"), @123, // left
              UTF8("\xe2\x87\xa5"), @48,  // tab
              UTF8("\xe2\x8e\x8b"), @53,  // escape
-             UTF8("\xe2\x8c\xa7"), @71,  // clear
+             @"⊞⌧", @(kVK_ANSI_KeypadClear), // numpad clear
              UTF8("\xe2\x8c\xab"), @51,  // delete
              UTF8("\xe2\x8c\xa6"), @117, // forward delete
              UTF8("?\xe2\x83\x9d"), @114, // help
@@ -177,7 +177,7 @@ static NSString* kLeftTabString = @"\xe2\x87\xa4";
              UTF8("\xe2\x87\x9e"), @116, // pgup
              UTF8("\xe2\x87\x9f"), @121, // pgdn
              UTF8("\xe2\x86\xa9"), @36,  // return
-             UTF8("\xe2\x86\xa9"), @76,  // numpad enter
+             @"⊞↩", @(kVK_ANSI_KeypadEnter), // numpad enter
              UTF8("\xf0\x9f\x94\x85"), @145, // low brightness
              UTF8("\xf0\x9f\x94\x86"), @144, // high brightness
              UTF8("\xf0\x9f\x96\xa5"), @160, // mission control
@@ -207,6 +207,23 @@ static NSString* kLeftTabString = @"\xe2\x87\xa4";
              @"F18 ", @79,  // F18
              @"F19 ", @80,  // F19
              @"F20 ", @90,  // F20
+             @"⊞.", @(kVK_ANSI_KeypadDecimal),
+             @"⊞*", @(kVK_ANSI_KeypadMultiply),
+             @"⊞+", @(kVK_ANSI_KeypadPlus),
+             @"⊞/", @(kVK_ANSI_KeypadDivide),
+             @"⊞-", @(kVK_ANSI_KeypadMinus),
+             @"⊞=", @(kVK_ANSI_KeypadEquals),
+             @"⊞0", @(kVK_ANSI_Keypad0),
+             @"⊞1", @(kVK_ANSI_Keypad1),
+             @"⊞2", @(kVK_ANSI_Keypad2),
+             @"⊞3", @(kVK_ANSI_Keypad3),
+             @"⊞4", @(kVK_ANSI_Keypad4),
+             @"⊞5", @(kVK_ANSI_Keypad5),
+             @"⊞6", @(kVK_ANSI_Keypad6),
+             @"⊞7", @(kVK_ANSI_Keypad7),
+             @"⊞8", @(kVK_ANSI_Keypad8),
+             @"⊞9", @(kVK_ANSI_Keypad9),
+             @"⊞,", @(kVK_JIS_KeypadComma),
              @"英数", @0x66, // eisū key, JIS keyboards only
              @"かな", @0x68, // kana key, JIS keyboards only
              nil];

--- a/keycastr/KCVisualizerTests/KCKeystrokeConversionTests.m
+++ b/keycastr/KCVisualizerTests/KCKeystrokeConversionTests.m
@@ -78,6 +78,67 @@
 
 #pragma mark - Numbers
 
+- (void)test_KCKeystroke_distinguishesNumericKeypadKeys {
+    // Arrange
+    NSDictionary<NSNumber *, NSString *> *expectedStringsByKeyCode = @{
+        @(kVK_ANSI_KeypadDecimal): @"⊞.",
+        @(kVK_ANSI_KeypadMultiply): @"⊞*",
+        @(kVK_ANSI_KeypadPlus): @"⊞+",
+        @(kVK_ANSI_KeypadClear): @"⊞⌧",
+        @(kVK_ANSI_KeypadDivide): @"⊞/",
+        @(kVK_ANSI_KeypadEnter): @"⊞↩",
+        @(kVK_ANSI_KeypadMinus): @"⊞-",
+        @(kVK_ANSI_KeypadEquals): @"⊞=",
+        @(kVK_ANSI_Keypad0): @"⊞0",
+        @(kVK_ANSI_Keypad1): @"⊞1",
+        @(kVK_ANSI_Keypad2): @"⊞2",
+        @(kVK_ANSI_Keypad3): @"⊞3",
+        @(kVK_ANSI_Keypad4): @"⊞4",
+        @(kVK_ANSI_Keypad5): @"⊞5",
+        @(kVK_ANSI_Keypad6): @"⊞6",
+        @(kVK_ANSI_Keypad7): @"⊞7",
+        @(kVK_ANSI_Keypad8): @"⊞8",
+        @(kVK_ANSI_Keypad9): @"⊞9",
+        @(kVK_JIS_KeypadComma): @"⊞,"
+    };
+
+    for (NSNumber *keyCode in expectedStringsByKeyCode) {
+        keystroke = [self keystrokeWithKeyCode:keyCode.unsignedShortValue
+                                     modifiers:0
+                                     characters:@""
+                            charactersIgnoringModifiers:@""];
+
+        // Act
+        NSString *convertedString = [eventTransformer transformedValue:keystroke];
+
+        // Assert
+        XCTAssertEqualObjects(convertedString, expectedStringsByKeyCode[keyCode]);
+    }
+}
+
+- (void)test_KCKeystroke_keepsMainKeyboardKeysUnprefixed {
+    // Arrange
+    NSDictionary<NSNumber *, NSString *> *expectedStringsByKeyCode = @{
+        @(kVK_ANSI_1): @"1",
+        @(kVK_ANSI_Period): @".",
+        @(kVK_Return): @"↩"
+    };
+
+    for (NSNumber *keyCode in expectedStringsByKeyCode) {
+        NSString *expectedString = expectedStringsByKeyCode[keyCode];
+        keystroke = [self keystrokeWithKeyCode:keyCode.unsignedShortValue
+                                     modifiers:0
+                                     characters:expectedString
+                            charactersIgnoringModifiers:expectedString];
+
+        // Act
+        NSString *convertedString = [eventTransformer transformedValue:keystroke];
+
+        // Assert
+        XCTAssertEqualObjects(convertedString, expectedString);
+    }
+}
+
 - (void)test_KCKeystroke_convertsCtrlNumberToNumber {
     // ctrl-7
     keystroke = [self keystrokeWithKeyCode:26 modifiers:262401 characters:@"7" charactersIgnoringModifiers:@"7"];


### PR DESCRIPTION
I know @akitchen already mentioned that they're not accepting PRs for this, but I needed to record a video yesterday with this feature, so I built it anyway. This PR serves as a potential reference that can be adapted to the new version, I'll close it immediately after opening.

-----

Fixes #224 re #296

KeyCastr currently renders numeric keypad keys the same way as their main keyboard equivalents, which makes it impossible to tell which key was pressed in demos.

This prefixes every keypad key with `⊞`, including digits, operators, decimal, Clear, Enter, equals, and the JIS keypad comma. Main keyboard keys keep their existing labels.

I added coverage for the complete keypad mapping and the matching main keyboard keys.